### PR TITLE
Connect fixes

### DIFF
--- a/client2-sim/go.mod
+++ b/client2-sim/go.mod
@@ -1,5 +1,5 @@
 module bringyour.com/connect/client2-sim
 
-go 1.21.0
+go 1.22.0
 
 require golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect

--- a/connect/go.mod
+++ b/connect/go.mod
@@ -1,6 +1,6 @@
 module bringyour.com/connect
 
-go 1.21.0
+go 1.22.0
 
 require (
 	bringyour.com/protocol v0.0.0

--- a/connect/transfer.go
+++ b/connect/transfer.go
@@ -274,6 +274,10 @@ func (self *Client) InstanceId() Id {
 	return self.instanceId
 }
 
+func (self *Client) SetInstanceId(instanceId Id) {
+	self.instanceId = instanceId
+}
+
 func (self *Client) ReportAbuse(sourceId Id) {
 	peerAudit := NewSequencePeerAudit(self, sourceId, 0)
 	peerAudit.Update(func (peerAudit *PeerAudit) {

--- a/connect/transfer_contract_manager.go
+++ b/connect/transfer_contract_manager.go
@@ -5,17 +5,10 @@ import (
 	"time"
 	"sync"
 	"errors"
-	// "container/heap"
-	// "sort"
-	// "math"
-	// "math/rand"
-	// "reflect"
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/rand"
-	// "runtime/debug"
 	"fmt"
-	// "slices"
 
 	"golang.org/x/exp/maps"
 

--- a/connect/transfer_contract_manager.go
+++ b/connect/transfer_contract_manager.go
@@ -1,0 +1,421 @@
+package connect
+
+import (
+	"context"
+	"time"
+	"sync"
+	"errors"
+	// "container/heap"
+	// "sort"
+	// "math"
+	// "math/rand"
+	// "reflect"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/rand"
+	// "runtime/debug"
+	"fmt"
+	// "slices"
+
+	"golang.org/x/exp/maps"
+
+	"google.golang.org/protobuf/proto"
+
+	"bringyour.com/protocol"
+)
+
+
+// manage contracts which are embedded into each transfer sequence
+
+
+func DefaultContractManagerSettings() *ContractManagerSettings {
+	return &ContractManagerSettings{
+		StandardTransferByteCount: gib(8),
+	}
+}
+
+
+type ContractManagerSettings struct {
+	StandardTransferByteCount ByteCount
+}
+
+
+type ContractManager struct {
+	ctx context.Context
+	client *Client
+
+	contractManagerSettings *ContractManagerSettings
+
+	mutex sync.Mutex
+
+	provideSecretKeys map[protocol.ProvideMode][]byte
+
+	destinationContracts map[Id]*ContractQueue
+	
+	receiveNoContractClientIds map[Id]bool
+	sendNoContractClientIds map[Id]bool
+
+	contractErrorCallbacks *CallbackList[ContractErrorFunction]
+}
+
+func NewContractManagerWithDefaults(ctx context.Context, client *Client) *ContractManager {
+	return NewContractManager(ctx, client, DefaultContractManagerSettings())
+}
+
+func NewContractManager(ctx context.Context, client *Client, contractManagerSettings *ContractManagerSettings) *ContractManager {
+	// at a minimum 
+	// - messages to/from the platform (ControlId) do not need a contract
+	//   this is because the platform is needed to create contracts
+	// - messages to self do not need a contract
+	receiveNoContractClientIds := map[Id]bool{
+		ControlId: true,
+		client.ClientId(): true,
+	}
+	sendNoContractClientIds := map[Id]bool{
+		ControlId: true,
+		client.ClientId(): true,
+	}
+
+	contractManager := &ContractManager{
+		ctx: ctx,
+		client: client,
+		contractManagerSettings: contractManagerSettings,
+		provideSecretKeys: map[protocol.ProvideMode][]byte{},
+		destinationContracts: map[Id]*ContractQueue{},
+		receiveNoContractClientIds: receiveNoContractClientIds,
+		sendNoContractClientIds: sendNoContractClientIds,
+		contractErrorCallbacks: NewCallbackList[ContractErrorFunction](),
+	}
+
+	client.AddReceiveCallback(contractManager.receive)
+
+	return contractManager
+}
+
+func (self *ContractManager) StandardTransferByteCount() ByteCount {
+	return self.contractManagerSettings.StandardTransferByteCount
+}
+
+func (self *ContractManager) addContractErrorCallback(contractErrorCallback ContractErrorFunction) {
+	self.contractErrorCallbacks.Add(contractErrorCallback)
+}
+
+func (self *ContractManager) removeContractErrorCallback(contractErrorCallback ContractErrorFunction) {
+	self.contractErrorCallbacks.Remove(contractErrorCallback)
+}
+
+// ReceiveFunction
+func (self *ContractManager) receive(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
+	switch sourceId {
+	case ControlId:
+		for _, frame := range frames {
+			if message, err := FromFrame(frame); err == nil {
+				switch v := message.(type) {
+				case *protocol.CreateContractResult:
+					if contractError := v.Error; contractError != nil {
+						self.error(*contractError)
+					} else if contract := v.Contract; contract != nil {
+						err := self.addContract(contract)
+						if err != nil {
+							panic(err)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// ContractErrorFunction
+func (self *ContractManager) error(contractError protocol.ContractError) {
+	for _, contractErrorCallback := range self.contractErrorCallbacks.Get() {
+		func() {
+			defer recover()
+			contractErrorCallback(contractError)
+		}()
+	}
+}
+
+func (self *ContractManager) SetProvideModes(provideModes map[protocol.ProvideMode]bool) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	currentProvideModes := maps.Keys(self.provideSecretKeys)
+	for _, provideMode := range currentProvideModes {
+		if allow, ok := provideModes[provideMode]; !ok || !allow {
+			delete(self.provideSecretKeys, provideMode)
+		}
+	}
+
+	provideKeys := []*protocol.ProvideKey{}
+	for provideMode, allow := range provideModes {
+		if allow {
+			provideSecretKey, ok := self.provideSecretKeys[provideMode]
+			if !ok {
+				// generate a new key
+				provideSecretKey = make([]byte, 32)
+		    	_, err := rand.Read(provideSecretKey)
+		    	if err != nil {
+		    		panic(err)
+		    	}
+				self.provideSecretKeys[provideMode] = provideSecretKey
+			}
+			provideKeys = append(provideKeys, &protocol.ProvideKey{
+				Mode: provideMode,
+				ProvideSecretKey: provideSecretKey,
+			})
+		}
+	}
+
+	provide := &protocol.Provide{
+		Keys: provideKeys,
+	}
+	self.client.SendControl(RequireToFrame(provide), func(err error) {
+		transferLog("Set provide complete (%s)", err)
+	})
+}
+
+func (self *ContractManager) Verify(storedContractHmac []byte, storedContractBytes []byte, provideMode protocol.ProvideMode) bool {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	provideSecretKey, ok := self.provideSecretKeys[provideMode]
+	if !ok {
+		// provide mode is not enabled
+		return false
+	}
+
+	mac := hmac.New(sha256.New, provideSecretKey)
+	expectedHmac := mac.Sum(storedContractBytes)
+	return hmac.Equal(storedContractHmac, expectedHmac)
+}
+
+func (self *ContractManager) GetProvideSecretKey(provideMode protocol.ProvideMode) ([]byte, bool) {
+	provideSecretKey, ok := self.provideSecretKeys[provideMode]
+	return provideSecretKey, ok
+}
+
+func (self *ContractManager) RequireProvideSecretKey(provideMode protocol.ProvideMode) []byte {
+	secretKey, ok := self.GetProvideSecretKey(provideMode)
+	if !ok {
+		panic(fmt.Errorf("Missing provide secret for %s", provideMode))
+	}
+	return secretKey
+}
+
+func (self *ContractManager) AddNoContractPeer(clientId Id) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	self.sendNoContractClientIds[clientId] = true
+	self.receiveNoContractClientIds[clientId] = true
+}
+
+func (self *ContractManager) SendNoContract(destinationId Id) bool {
+	// FIXME
+	if true {
+		return true
+	}
+
+
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	if allow, ok := self.sendNoContractClientIds[destinationId]; ok {
+		return allow
+	}
+	return false
+}
+
+func (self *ContractManager) ReceiveNoContract(sourceId Id) bool {
+	// FIXME
+	if true {
+		return true
+	}
+
+
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	if allow, ok := self.receiveNoContractClientIds[sourceId]; ok {
+		return allow
+	}
+	return false
+}
+
+func (self *ContractManager) TakeContract(ctx context.Context, destinationId Id, timeout time.Duration) *protocol.Contract {
+	contractQueue := self.openContractQueue(destinationId)
+	defer self.closeContractQueue(destinationId)
+
+	enterTime := time.Now()
+	for {
+		notify := contractQueue.updateMonitor.NotifyChannel()
+		contract := contractQueue.poll()
+
+		if contract != nil {
+			return contract
+		}
+
+		if timeout < 0 {
+			select {
+			case <- self.ctx.Done():
+				return nil
+			case <- ctx.Done():
+				return nil
+			case <- notify:
+			}
+		} else if timeout == 0 {
+			return nil
+		} else {
+			remainingTimeout := enterTime.Add(timeout).Sub(time.Now())
+			select {
+			case <- self.ctx.Done():
+				return nil
+			case <- ctx.Done():
+				return nil
+			case <- notify:
+			case <- time.After(remainingTimeout):
+				return nil
+			}
+		}
+	}
+}
+
+func (self *ContractManager) addContract(contract *protocol.Contract) error {
+	var storedContract protocol.StoredContract
+	err := proto.Unmarshal(contract.StoredContractBytes, &storedContract)
+	if err != nil {
+		return err
+	}
+
+	sourceId, err := IdFromBytes(storedContract.SourceId)
+	if err != nil {
+		return err
+	}
+
+	if self.client.ClientId() != sourceId {
+		return errors.New("Contract source must be this client.")
+	}
+
+	destinationId, err := IdFromBytes(storedContract.DestinationId)
+	if err != nil {
+		return err
+	}
+
+	contractQueue := self.openContractQueue(destinationId)
+	defer self.closeContractQueue(destinationId)
+
+	contractQueue.add(contract)
+	return nil
+}
+
+func (self *ContractManager) openContractQueue(destinationId Id) *ContractQueue {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	contractQueue, ok := self.destinationContracts[destinationId]
+	if !ok {
+		contractQueue = NewContractQueue()
+		self.destinationContracts[destinationId] = contractQueue
+	}
+	contractQueue.open()
+
+	return contractQueue
+}
+
+func (self *ContractManager) closeContractQueue(destinationId Id) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	contractQueue, ok := self.destinationContracts[destinationId]
+	if !ok {
+		panic("Open and close must be equally paired")
+	}
+	contractQueue.close()
+	if contractQueue.empty() {
+		delete(self.destinationContracts, destinationId)
+	}
+}
+
+func (self *ContractManager) CreateContract(destinationId Id) {
+	// look at destinationContracts and last contract to get previous contract id
+	createContract := &protocol.CreateContract{
+		DestinationId: destinationId.Bytes(),
+		TransferByteCount: uint64(self.contractManagerSettings.StandardTransferByteCount),
+	}
+	self.client.SendControl(RequireToFrame(createContract), nil)
+}
+
+func (self *ContractManager) Complete(contractId Id, ackedByteCount ByteCount, unackedByteCount ByteCount) {
+	closeContract := &protocol.CloseContract{
+		ContractId: contractId.Bytes(),
+		AckedByteCount: uint64(ackedByteCount),
+		UnackedByteCount: uint64(unackedByteCount),
+	}
+	self.client.SendControl(RequireToFrame(closeContract), nil)
+}
+
+func (self *ContractManager) Close() {
+	// FIXME close known pending contracts
+	// pending contracts in flight will just timeout on the platform
+	self.client.RemoveReceiveCallback(self.receive)
+}
+
+
+type ContractQueue struct {
+	updateMonitor *Monitor
+
+	mutex sync.Mutex
+	openCount int
+	contracts []*protocol.Contract
+}
+
+func NewContractQueue() *ContractQueue {
+	return &ContractQueue{
+		updateMonitor: NewMonitor(),
+		openCount: 0,
+		contracts: []*protocol.Contract{},
+	}
+}
+
+func (self *ContractQueue) open() {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+	self.openCount += 1
+}
+
+func (self *ContractQueue) close() {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+	self.openCount -= 1
+}
+
+func (self *ContractQueue) poll() *protocol.Contract {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	if len(self.contracts) == 0 {
+		return nil
+	}
+
+	contract := self.contracts[0]
+	self.contracts[0] = nil
+	self.contracts = self.contracts[1:]
+	return contract
+}
+
+func (self *ContractQueue) add(contract *protocol.Contract) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	self.contracts = append(self.contracts, contract)
+
+	self.updateMonitor.NotifyAll()
+}
+
+func (self *ContractQueue) empty() bool {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	return 0 == self.openCount && 0 == len(self.contracts)
+}

--- a/connect/transfer_queue.go
+++ b/connect/transfer_queue.go
@@ -3,9 +3,7 @@ package connect
 import (
     "container/heap"
     "sync"
-    // "sort"
 )
-
 
 
 type transferQueueItem interface {

--- a/connect/transfer_queue.go
+++ b/connect/transfer_queue.go
@@ -1,0 +1,305 @@
+package connect
+
+import (
+    "container/heap"
+    "sync"
+    // "sort"
+)
+
+
+
+type transferQueueItem interface {
+    MessageId() Id
+    MessageByteCount() ByteCount
+    SequenceNumber() uint64
+    HeapIndex() int
+    SetHeapIndex(int)
+    MaxHeapIndex() int
+    SetMaxHeapIndex(int)
+}
+
+
+type transferItem struct {
+    messageId Id
+    messageByteCount ByteCount
+    sequenceNumber uint64
+    
+    // the index of the item in the heap
+    heapIndex int
+    // the index of the item in the max heap
+    maxHeapIndex int
+}
+
+// transferQueueItem implementation
+
+func (self *transferItem) MessageId() Id {
+    return self.messageId
+}
+
+func (self *transferItem) MessageByteCount() ByteCount {
+    return self.messageByteCount
+}
+
+func (self *transferItem) SequenceNumber() uint64 {
+    return self.sequenceNumber
+}
+
+func (self *transferItem) HeapIndex() int {
+    return self.heapIndex
+}
+
+func (self *transferItem) SetHeapIndex(heapIndex int) {
+    self.heapIndex = heapIndex
+}
+
+func (self *transferItem) MaxHeapIndex() int {
+    return self.maxHeapIndex
+}
+
+func (self *transferItem) SetMaxHeapIndex(maxHeapIndex int) {
+    self.maxHeapIndex = maxHeapIndex
+}
+
+
+type TransferQueueCmpFunction[T transferQueueItem] func(a T, b T)(int)
+
+
+// ordered by sequenceNumber
+type transferQueue[T transferQueueItem] struct {
+    orderedItems []T
+    maxHeap *transferQueueMaxHeap[T]
+    // message_id -> item
+    messageIdItems map[Id]T
+    sequenceNumberItems map[uint64]T
+    byteCount ByteCount
+    stateLock sync.Mutex
+
+    cmp TransferQueueCmpFunction[T]
+}
+
+func newTransferQueue[T transferQueueItem](cmp TransferQueueCmpFunction[T]) *transferQueue[T] {
+    transferQueue := &transferQueue[T]{
+        orderedItems: []T{},
+        maxHeap: newTransferQueueMaxHeap[T](cmp),
+        messageIdItems: map[Id]T{},
+        sequenceNumberItems: map[uint64]T{},
+        byteCount: 0,
+        cmp: cmp,
+    }
+    heap.Init(transferQueue)
+    return transferQueue
+}
+
+func (self *transferQueue[T]) QueueSize() (int, ByteCount) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    return len(self.orderedItems), self.byteCount
+}
+
+func (self *transferQueue[T]) Add(item T) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    self.messageIdItems[item.MessageId()] = item
+    self.sequenceNumberItems[item.SequenceNumber()] = item
+    heap.Push(self, item)
+    heap.Push(self.maxHeap, item)
+    self.byteCount += item.MessageByteCount()
+}
+
+func (self *transferQueue[T]) RemoveByMessageId(messageId Id) T {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    item, ok := self.messageIdItems[messageId]
+    if !ok {
+        var empty T
+        return empty
+    }
+    return self.remove(item)
+}
+
+func (self *transferQueue[T]) RemoveBySequenceNumber(sequenceNumber uint64) T {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    item, ok := self.sequenceNumberItems[sequenceNumber]
+    if !ok {
+        var empty T
+        return empty
+    }
+    return self.remove(item)
+}
+
+func (self *transferQueue[T]) GetByMessageId(messageId Id) T {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    item, ok := self.messageIdItems[messageId]
+    if !ok {
+        var empty T
+        return empty
+    }
+    return item
+}
+
+func (self *transferQueue[T]) GetBySequenceNumber(sequenceNumber uint64) T {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    item, ok := self.sequenceNumberItems[sequenceNumber]
+    if !ok {
+        var empty T
+        return empty
+    }
+    return item
+}
+
+func (self *transferQueue[T]) remove(item T) T {
+    delete(self.messageIdItems, item.MessageId())
+    delete(self.sequenceNumberItems, item.SequenceNumber())
+    item_ := heap.Remove(self, item.HeapIndex())
+    if any(item) != item_ {
+        panic("Heap invariant broken.")
+    }
+    heap.Remove(self.maxHeap, item.MaxHeapIndex())
+    self.byteCount -= item.MessageByteCount()
+    return item
+}
+
+func (self *transferQueue[T]) RemoveFirst() T {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    if len(self.orderedItems) == 0 {
+        var empty T
+        return empty
+    }
+
+    item := heap.Remove(self, 0).(T)
+    heap.Remove(self.maxHeap, item.MaxHeapIndex())
+    delete(self.messageIdItems, item.MessageId())
+    delete(self.sequenceNumberItems, item.SequenceNumber())
+    self.byteCount -= item.MessageByteCount()
+    return item
+}
+
+func (self *transferQueue[T]) PeekFirst() T {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    if len(self.orderedItems) == 0 {
+        var empty T
+        return empty
+    }
+    return self.orderedItems[0]
+}
+
+func (self *transferQueue[T]) PeekLast() T {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    return self.maxHeap.PeekFirst()
+}
+
+// heap.Interface
+
+func (self *transferQueue[T]) Push(x any) {
+    item := x.(T)
+    item.SetHeapIndex(len(self.orderedItems))
+    self.orderedItems = append(self.orderedItems, item)
+}
+
+func (self *transferQueue[T]) Pop() any {
+    n := len(self.orderedItems)
+    i := n - 1
+    var empty T
+    item := self.orderedItems[i]
+    self.orderedItems[i] = empty
+    self.orderedItems = self.orderedItems[:n-1]
+    return item
+}
+
+// sort.Interface
+
+func (self *transferQueue[T]) Len() int {
+    return len(self.orderedItems)
+}
+
+func (self *transferQueue[T]) Less(i int, j int) bool {
+    return self.cmp(self.orderedItems[i], self.orderedItems[j]) < 0
+}
+
+func (self *transferQueue[T]) Swap(i int, j int) {
+    a := self.orderedItems[i]
+    b := self.orderedItems[j]
+    b.SetHeapIndex(i)
+    self.orderedItems[i] = b
+    a.SetHeapIndex(j)
+    self.orderedItems[j] = a
+}
+
+
+// ordered by `sequenceNumber` descending
+type transferQueueMaxHeap[T transferQueueItem] struct {
+    orderedItems []T
+
+    cmp TransferQueueCmpFunction[T]
+}
+
+func newTransferQueueMaxHeap[T transferQueueItem](cmp TransferQueueCmpFunction[T]) *transferQueueMaxHeap[T] {
+    transferQueueMaxHeap := &transferQueueMaxHeap[T]{
+        orderedItems: []T{},
+        cmp: cmp,
+    }
+    heap.Init(transferQueueMaxHeap)
+    return transferQueueMaxHeap
+}
+
+func (self *transferQueueMaxHeap[T]) PeekFirst() T {
+    if len(self.orderedItems) == 0 {
+        var empty T
+        return empty
+    }
+    return self.orderedItems[0]
+}
+
+// heap.Interface
+
+func (self *transferQueueMaxHeap[T]) Push(x any) {
+    item := x.(T)
+    item.SetMaxHeapIndex(len(self.orderedItems))
+    self.orderedItems = append(self.orderedItems, item)
+}
+
+func (self *transferQueueMaxHeap[T]) Pop() any {
+    n := len(self.orderedItems)
+    i := n - 1
+    var empty T
+    item := self.orderedItems[i]
+    self.orderedItems[i] = empty
+    self.orderedItems = self.orderedItems[:n-1]
+    return item
+}
+
+// sort.Interface
+
+func (self *transferQueueMaxHeap[T]) Len() int {
+    return len(self.orderedItems)
+}
+
+func (self *transferQueueMaxHeap[T]) Less(i int, j int) bool {
+    return 0 <= self.cmp(self.orderedItems[i], self.orderedItems[j])
+}
+
+func (self *transferQueueMaxHeap[T]) Swap(i int, j int) {
+    a := self.orderedItems[i]
+    b := self.orderedItems[j]
+    b.SetMaxHeapIndex(i)
+    self.orderedItems[i] = b
+    a.SetMaxHeapIndex(j)
+    self.orderedItems[j] = a
+}
+
+

--- a/connect/transfer_queue_test.go
+++ b/connect/transfer_queue_test.go
@@ -1,0 +1,140 @@
+package connect
+
+import (
+    "testing"
+    mathrand "math/rand"
+
+    "github.com/go-playground/assert/v2"
+)
+
+
+
+
+
+
+func TestTransferQueue(t *testing.T) {
+
+	type myTransferItem struct {
+		transferItem
+	}
+
+
+	queue := newTransferQueue[*myTransferItem](func(a *myTransferItem, b *myTransferItem)(int) {
+		if a.sequenceNumber < b.sequenceNumber {
+			return -1
+		} else if b.sequenceNumber < a.sequenceNumber {
+			return 1
+		} else {
+			return 0
+		}
+	})
+
+	size, byteSize := queue.QueueSize()
+	assert.Equal(t, 0, size)
+	assert.Equal(t, 0, byteSize)
+
+	n := 100
+
+	items := []*myTransferItem{}
+	sequenceNumberMessageIds := map[uint64]Id{}
+	for i := 0; i < n; i += 1 {
+		item := &myTransferItem{
+			transferItem: transferItem{
+				messageId: NewId(),
+			    messageByteCount: ByteCount(1),
+			    sequenceNumber: uint64(i),
+			},
+		}
+		items = append(items, item)
+		sequenceNumberMessageIds[item.sequenceNumber] = item.messageId
+	}
+
+
+	// add a bunch and test peekFirst, peekLast
+	// remove first
+	mathrand.Shuffle(len(items), func(i, j int) {
+		items[i], items[j] = items[j], items[i]
+	})
+	for _, item := range items {
+		queue.Add(item)
+	}
+
+	for sequenceNumber, messageId := range sequenceNumberMessageIds {
+		item := queue.GetByMessageId(messageId)
+		assert.NotEqual(t, item, nil)
+		assert.Equal(t, sequenceNumber, item.sequenceNumber)
+	}
+
+	for sequenceNumber, messageId := range sequenceNumberMessageIds {
+		item := queue.GetBySequenceNumber(sequenceNumber)
+		assert.NotEqual(t, item, nil)
+		assert.Equal(t, messageId, item.messageId)
+	}
+	
+	for i := 0; i < n; i += 1 {
+		size, byteSize = queue.QueueSize()
+		assert.Equal(t, n-i, size)
+		assert.Equal(t, ByteCount(n-i), byteSize)
+
+		assert.Equal(t, uint64(i), queue.PeekFirst().sequenceNumber)
+		assert.Equal(t, uint64(n - 1), queue.PeekLast().sequenceNumber)
+
+		first := queue.RemoveFirst()
+		assert.Equal(t, uint64(i), first.sequenceNumber)
+	}
+	size, byteSize = queue.QueueSize()
+	assert.Equal(t, 0, size)
+	assert.Equal(t, ByteCount(0), byteSize)
+
+
+	// add a bunch and test peekFirst, peekLast
+	// remove by id
+	mathrand.Shuffle(len(items), func(i, j int) {
+		items[i], items[j] = items[j], items[i]
+	})
+	for _, item := range items {
+		queue.Add(item)
+	}
+	
+	for i := 0; i < n; i += 1 {
+		size, byteSize = queue.QueueSize()
+		assert.Equal(t, n-i, size)
+		assert.Equal(t, ByteCount(n-i), byteSize)
+
+		assert.Equal(t, uint64(i), queue.PeekFirst().sequenceNumber)
+		assert.Equal(t, uint64(n - 1), queue.PeekLast().sequenceNumber)
+
+		messageId := sequenceNumberMessageIds[uint64(i)]
+		first := queue.RemoveByMessageId(messageId)
+		assert.Equal(t, uint64(i), first.sequenceNumber)
+	}
+	size, byteSize = queue.QueueSize()
+	assert.Equal(t, 0, size)
+	assert.Equal(t, ByteCount(0), byteSize)
+
+
+	// add a bunch and test peekFirst, peekLast
+	// remove by sequence number
+	mathrand.Shuffle(len(items), func(i, j int) {
+		items[i], items[j] = items[j], items[i]
+	})
+	for _, item := range items {
+		queue.Add(item)
+	}
+
+	for i := 0; i < n; i += 1 {
+		size, byteSize = queue.QueueSize()
+		assert.Equal(t, n-i, size)
+		assert.Equal(t, ByteCount(n-i), byteSize)
+
+		assert.Equal(t, uint64(i), queue.PeekFirst().sequenceNumber)
+		assert.Equal(t, uint64(n - 1), queue.PeekLast().sequenceNumber)
+
+		first := queue.RemoveBySequenceNumber(uint64(i))
+		assert.Equal(t, uint64(i), first.sequenceNumber)
+	}
+	size, byteSize = queue.QueueSize()
+	assert.Equal(t, 0, size)
+	assert.Equal(t, ByteCount(0), byteSize)
+
+}

--- a/connect/transfer_queue_test.go
+++ b/connect/transfer_queue_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 
-
-
-
-
 func TestTransferQueue(t *testing.T) {
 
 	type myTransferItem struct {

--- a/connect/transfer_route_manager.go
+++ b/connect/transfer_route_manager.go
@@ -1,0 +1,926 @@
+package connect
+
+import (
+	"context"
+	"time"
+	"sync"
+	"errors"
+	// "container/heap"
+	// "sort"
+	// "math"
+	mathrand "math/rand"
+	"reflect"
+	// "crypto/hmac"
+	// "crypto/sha256"
+	// "runtime/debug"
+	// "fmt"
+	"slices"
+
+	"golang.org/x/exp/maps"
+
+	// "google.golang.org/protobuf/proto"
+
+	// "bringyour.com/protocol"
+)
+
+
+// manage multiple routes to a destination, allowing weighted reads and writes to the routes
+// this assumes the source is a single client
+
+
+// routes are expected to have flow control and error detection and rejection
+type Route = chan []byte
+
+
+// each transport must have a unique local id
+// This solves an issue where some transports can be implemented with zero state.
+// Zero state transports makes it ambiguous whether the transport pointer can be used as a key.
+// see https://github.com/golang/go/issues/65878
+type Transport interface {
+    TransportId() Id
+    
+    // lower priority takes precedence
+    Priority() int
+    
+    CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool
+    // returns the fraction of route weight that should be allocated to this transport
+    // the remaining are the lower priority transports
+    // call `rematchTransport` to re-evaluate the weights. this is used for a control loop where the weight is adjusted to match the actual distribution
+    RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32
+    
+    MatchesSend(destinationId Id) bool
+    MatchesReceive(destinationId Id) bool
+
+    // request that p2p and direct connections be re-established that include the source
+    // connections will be denied for sources that have bad audits
+    Downgrade(sourceId Id)
+}
+
+
+type MultiRouteWriter interface {
+    Write(ctx context.Context, transportFrameBytes []byte, timeout time.Duration) error
+    GetActiveRoutes() []Route
+    GetInactiveRoutes() []Route
+}
+
+
+type MultiRouteReader interface {
+    Read(ctx context.Context, timeout time.Duration) ([]byte, error)
+    GetActiveRoutes() []Route
+    GetInactiveRoutes() []Route
+}
+
+
+type RouteManager struct {
+	ctx context.Context
+    client *Client
+
+    mutex sync.Mutex
+    writerMatchState *MatchState
+    readerMatchState *MatchState
+}
+
+func NewRouteManager(ctx context.Context, client *Client) *RouteManager {
+    return &RouteManager{
+    	ctx: ctx,
+        client: client,
+        writerMatchState: NewMatchState(ctx, true, Transport.MatchesSend),
+        // `weightedRoutes=false` because unless there is a cpu limit this is not needed
+        readerMatchState: NewMatchState(ctx, false, Transport.MatchesReceive),
+    }
+}
+
+func (self *RouteManager) DowngradeReceiverConnection(sourceId Id) {
+    self.readerMatchState.Downgrade(sourceId)
+}
+
+func (self *RouteManager) OpenMultiRouteWriter(destinationId Id) MultiRouteWriter {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    return MultiRouteWriter(self.writerMatchState.openMultiRouteSelector(destinationId))
+}
+
+func (self *RouteManager) CloseMultiRouteWriter(w MultiRouteWriter) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    self.writerMatchState.closeMultiRouteSelector(w.(*MultiRouteSelector))
+}
+
+func (self *RouteManager) OpenMultiRouteReader(destinationId Id) MultiRouteReader {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    return MultiRouteReader(self.readerMatchState.openMultiRouteSelector(destinationId))
+}
+
+func (self *RouteManager) CloseMultiRouteReader(r MultiRouteReader) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    self.readerMatchState.closeMultiRouteSelector(r.(*MultiRouteSelector))
+}
+
+func (self *RouteManager) UpdateTransport(transport Transport, routes []Route) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    self.writerMatchState.updateTransport(transport, routes)
+    self.readerMatchState.updateTransport(transport, routes)
+}
+
+func (self *RouteManager) RemoveTransport(transport Transport) {
+    self.UpdateTransport(transport, nil)
+}
+
+func (self *RouteManager) getTransportStats(transport Transport) (writerStats *RouteStats, readerStats *RouteStats) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    writerStats = self.writerMatchState.getTransportStats(transport)
+    readerStats = self.readerMatchState.getTransportStats(transport)
+    return
+}
+
+func (self *RouteManager) Close() {
+    // transports close individually and remove themselves via `updateTransport`
+}
+
+
+type MatchState struct {
+	ctx context.Context
+    weightedRoutes bool
+    matches func(Transport, Id)(bool)
+
+    transportRoutes map[Transport][]Route
+
+    // destination id -> multi route selectors
+    destinationMultiRouteSelectors map[Id]map[*MultiRouteSelector]bool
+
+    // transport -> destination ids
+    transportMatchedDestinations map[Transport]map[Id]bool
+}
+
+// note weighted routes typically are used by the sender not receiver
+func NewMatchState(ctx context.Context, weightedRoutes bool, matches func(Transport, Id)(bool)) *MatchState {
+    return &MatchState{
+    	ctx: ctx,
+        weightedRoutes: weightedRoutes,
+        matches: matches,
+        transportRoutes: map[Transport][]Route{},
+        destinationMultiRouteSelectors: map[Id]map[*MultiRouteSelector]bool{},
+        transportMatchedDestinations: map[Transport]map[Id]bool{},
+    }
+}
+
+func (self *MatchState) getTransportStats(transport Transport) *RouteStats {
+    destinationIds, ok := self.transportMatchedDestinations[transport]
+    if !ok {
+        return nil
+    }
+    netStats := NewRouteStats()
+    for destinationId, _ := range destinationIds {
+        if multiRouteSelectors, ok := self.destinationMultiRouteSelectors[destinationId]; ok {
+            for multiRouteSelector, _  := range multiRouteSelectors {
+                if stats := multiRouteSelector.getTransportStats(transport); stats != nil {
+                    netStats.sendCount += stats.sendCount
+                    netStats.sendByteCount += stats.sendByteCount
+                    netStats.receiveCount += stats.receiveCount
+                    netStats.receiveByteCount += stats.receiveByteCount
+                }
+            }
+        }
+    }
+    return netStats
+}
+
+func (self *MatchState) openMultiRouteSelector(destinationId Id) *MultiRouteSelector {
+    // fmt.Printf("create selector transports=%d\n", len(self.transportRoutes))
+
+    multiRouteSelector := NewMultiRouteSelector(self.ctx, destinationId, self.weightedRoutes)
+
+    multiRouteSelectors, ok := self.destinationMultiRouteSelectors[destinationId]
+    if !ok {
+        multiRouteSelectors = map[*MultiRouteSelector]bool{}
+        self.destinationMultiRouteSelectors[destinationId] = multiRouteSelectors
+    }
+    multiRouteSelectors[multiRouteSelector] = true
+
+    for transport, routes := range self.transportRoutes {
+        matchedDestinations, ok := self.transportMatchedDestinations[transport]
+        if !ok {
+            matchedDestinations := map[Id]bool{}
+            self.transportMatchedDestinations[transport] = matchedDestinations
+        }
+
+        // use the latest matches state
+        if self.matches(transport, destinationId) {
+            matchedDestinations[destinationId] = true
+            multiRouteSelector.updateTransport(transport, routes)
+        }
+    }
+
+    return multiRouteSelector
+}
+
+func (self *MatchState) closeMultiRouteSelector(multiRouteSelector *MultiRouteSelector) {
+    // TODO readers do not need to prioritize routes
+
+    destinationId := multiRouteSelector.destinationId
+    multiRouteSelectors, ok := self.destinationMultiRouteSelectors[destinationId]
+    if !ok {
+        // not present
+        return
+    }
+    delete(multiRouteSelectors, multiRouteSelector)
+
+    if len(multiRouteSelectors) == 0 {
+        // clean up the destination
+        for _, matchedDestinations := range self.transportMatchedDestinations {
+            delete(matchedDestinations, destinationId)
+        }
+    }
+}
+
+func (self *MatchState) updateTransport(transport Transport, routes []Route) {
+    // c := 0
+    // for _, multiRouteSelectors := range self.destinationMultiRouteSelectors {
+    //  c += len(multiRouteSelectors)
+    // }
+    // fmt.Printf("update transport selectors=%d routes=%v\n", c, routes)
+
+    if len(routes) == 0 {
+        if currentMatchedDestinations, ok := self.transportMatchedDestinations[transport]; ok {
+            for destinationId, _ := range currentMatchedDestinations {
+                if multiRouteSelectors, ok := self.destinationMultiRouteSelectors[destinationId]; ok {
+                    for multiRouteSelector, _ := range multiRouteSelectors {
+                        multiRouteSelector.updateTransport(transport, nil)
+                    }
+                }
+            }
+        }
+
+        delete(self.transportMatchedDestinations, transport)
+        delete(self.transportRoutes, transport)
+    } else {
+        matchedDestinations := map[Id]bool{}
+
+        currentMatchedDestinations, ok := self.transportMatchedDestinations[transport]
+        if !ok {
+            currentMatchedDestinations = map[Id]bool{}
+        }
+
+        for destinationId, multiRouteSelectors := range self.destinationMultiRouteSelectors {
+            if self.matches(transport, destinationId) {
+                matchedDestinations[destinationId] = true
+                for multiRouteSelector, _ := range multiRouteSelectors {
+                    multiRouteSelector.updateTransport(transport, routes)
+                }
+            } else if _, ok := currentMatchedDestinations[destinationId]; ok {
+                // no longer matches
+                for multiRouteSelector, _ := range multiRouteSelectors {
+                    multiRouteSelector.updateTransport(transport, nil)
+                }
+            }
+        }
+
+        self.transportMatchedDestinations[transport] = matchedDestinations
+        self.transportRoutes[transport] = routes
+    }
+}
+
+func (self *MatchState) Downgrade(sourceId Id) {
+    // FIXME request downgrade from the transports
+}
+
+
+type MultiRouteSelector struct {
+    ctx context.Context
+    cancel context.CancelFunc
+
+    destinationId Id
+    weightedRoutes bool
+
+    transportUpdate *Monitor
+
+    mutex sync.Mutex
+    transportRoutes map[Transport][]Route
+    routeStats map[Route]*RouteStats
+    routeActive map[Route]bool
+    routeWeight map[Route]float32
+}
+
+func NewMultiRouteSelector(ctx context.Context, destinationId Id, weightedRoutes bool) *MultiRouteSelector {
+	cancelCtx, cancel := context.WithCancel(ctx)
+    return &MultiRouteSelector{
+        ctx: cancelCtx,
+        cancel: cancel,
+        destinationId: destinationId,
+        weightedRoutes: weightedRoutes,
+        transportUpdate: NewMonitor(),
+        transportRoutes: map[Transport][]Route{},
+        routeStats: map[Route]*RouteStats{},
+        routeActive: map[Route]bool{},
+        routeWeight: map[Route]float32{},
+    }
+}
+
+func (self *MultiRouteSelector) getTransportStats(transport Transport) *RouteStats {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    currentRoutes, ok := self.transportRoutes[transport]
+    if !ok {
+        return nil
+    }
+    netStats := NewRouteStats()
+    for _, currentRoute := range currentRoutes {
+        if stats, ok := self.routeStats[currentRoute]; ok {
+            netStats.sendCount += stats.sendCount
+            netStats.sendByteCount += stats.sendByteCount
+            netStats.receiveCount += stats.receiveCount
+            netStats.receiveByteCount += stats.receiveByteCount
+        }
+    }
+    return netStats
+}
+
+// if weightedRoutes, this applies new priorities and weights. calling this resets all route stats.
+// the reason to reset weightedRoutes is that the weight calculation needs to consider only the stats since the previous weight change
+func (self *MultiRouteSelector) updateTransport(transport Transport, routes []Route) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    // activeRoutes := func()([]Route) {
+    //  activeRoutes := []Route{}
+    //  for _, routes := range self.transportRoutes {
+    //      for _, route := range routes {
+    //          if self.routeActive[route] {
+    //              activeRoutes = append(activeRoutes, route)
+    //          }
+    //      }
+    //  }
+    //  return activeRoutes
+    // }
+
+    // preTransportCount := len(self.transportRoutes)
+    // preActiveRouteCount := len(activeRoutes())
+
+    if len(routes) == 0 {
+        if currentRoutes, ok := self.transportRoutes[transport]; ok {
+            for _, currentRoute := range currentRoutes {
+                delete(self.routeStats, currentRoute)
+                delete(self.routeActive, currentRoute)
+                delete(self.routeWeight, currentRoute)
+            }
+            delete(self.transportRoutes, transport)
+        } else {
+            // transport is not active. nothing to do
+            return
+        }
+    } else {
+        if currentRoutes, ok := self.transportRoutes[transport]; ok {
+            for _, currentRoute := range currentRoutes {
+                if slices.Index(routes, currentRoute) < 0 {
+                    // no longer present
+                    delete(self.routeStats, currentRoute)
+                    delete(self.routeActive, currentRoute)
+                    delete(self.routeWeight, currentRoute)
+                }
+            }
+            for _, route := range routes {
+                if slices.Index(currentRoutes, route) < 0 {
+                    // new route
+                    self.routeActive[route] = true
+                }
+            }
+        } else {
+            for _, route := range routes {
+                // new route
+                self.routeActive[route] = true
+            }
+        }
+        // the following will be updated with the new routes in the weighting below
+        // - routeStats
+        // - routeActive
+        // - routeWeights
+        self.transportRoutes[transport] = routes
+    }
+
+    if self.weightedRoutes {
+        self.updateRouteWeights()
+    }
+
+    self.transportUpdate.NotifyAll()
+
+
+    // postTransportCount := len(self.transportRoutes)
+    // postActiveRouteCount := len(activeRoutes())
+        
+    // fmt.Printf("updated transports=%d->%d routes=%d->%d\n", preTransportCount, postTransportCount, preActiveRouteCount, postActiveRouteCount)
+}
+
+func (self *MultiRouteSelector) updateRouteWeights() {
+    updatedRouteWeight := map[Route]float32{}
+
+    transportStats := map[Transport]*RouteStats{}
+    for transport, currentRoutes := range self.transportRoutes {
+        netStats := NewRouteStats()
+        for _, currentRoute := range currentRoutes {
+            if stats, ok := self.routeStats[currentRoute]; ok {
+                netStats.sendCount += stats.sendCount
+                netStats.sendByteCount += stats.sendByteCount
+                netStats.receiveCount += stats.receiveCount
+                netStats.receiveByteCount += stats.receiveByteCount
+            }
+        }
+        transportStats[transport] = netStats
+    }
+
+    orderedTransports := maps.Keys(self.transportRoutes)
+    // shuffle the same priority values
+    mathrand.Shuffle(len(orderedTransports), func(i int, j int) {
+        t := orderedTransports[i]
+        orderedTransports[i] = orderedTransports[j]
+        orderedTransports[j] = t
+    })
+    slices.SortStableFunc(orderedTransports, func(a Transport, b Transport)(int) {
+        return a.Priority() - b.Priority()
+    })
+
+    n := len(orderedTransports)
+
+    allCanEval := true
+    for i := 0; i < n; i += 1 {
+        transport := orderedTransports[i]
+        routeStats := transportStats[transport]
+        remainingStats := map[Transport]*RouteStats{}
+        for j := i + 1; j < n; j += 1 {
+            remainingStats[orderedTransports[j]] = transportStats[orderedTransports[j]]
+        }
+        canEval := transport.CanEvalRouteWeight(routeStats, remainingStats)
+        allCanEval = allCanEval && canEval
+    }
+
+    if allCanEval {
+        var allWeight float32
+        allWeight = 1.0
+        for i := 0; i < n; i += 1 {
+            transport := orderedTransports[i]
+            routeStats := transportStats[transport]
+            remainingStats := map[Transport]*RouteStats{}
+            for j := i + 1; j < n; j += 1 {
+                remainingStats[orderedTransports[j]] = transportStats[orderedTransports[j]]
+            }
+            weight := transport.RouteWeight(routeStats, remainingStats)
+            for _, route := range self.transportRoutes[transport] {
+                updatedRouteWeight[route] = allWeight * weight
+            }
+            allWeight *= (1.0 - weight)
+        }
+
+        self.routeWeight = updatedRouteWeight
+
+        updatedRouteStats := map[Route]*RouteStats{}
+        for _, currentRoutes := range self.transportRoutes {
+            for _, currentRoute := range currentRoutes {
+                // reset the stats
+                updatedRouteStats[currentRoute] = NewRouteStats()
+            }
+        }
+        self.routeStats = updatedRouteStats
+    }
+}
+
+func (self *MultiRouteSelector) GetActiveRoutes() []Route {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    activeRoutes := []Route{}
+    for _, routes := range self.transportRoutes {
+        for _, route := range routes {
+            if self.routeActive[route] {
+                activeRoutes = append(activeRoutes, route)
+            }
+        }
+    }
+
+    mathrand.Shuffle(len(activeRoutes), func(i int, j int) {
+        activeRoutes[i], activeRoutes[j] = activeRoutes[j], activeRoutes[i]
+    })
+
+    if self.weightedRoutes {
+        // prioritize the routes (weighted shuffle)
+        // if all weights are equal, this is the same as a shuffle
+        n := len(activeRoutes)
+        for i := 0; i < n - 1; i += 1 {
+            j := func ()(int) {
+                var net float32
+                net = 0
+                for j := i; j < n; j += 1 {
+                    net += self.routeWeight[activeRoutes[j]]
+                }
+                r := mathrand.Float32()
+                rnet := r * net
+                net = 0
+                for j := i; j < n; j += 1 {
+                    net += self.routeWeight[activeRoutes[j]]
+                    if rnet < net {
+                        return j
+                    }
+                }
+                panic("Incorrect weights")
+            }()
+            t := activeRoutes[i]
+            activeRoutes[i] = activeRoutes[j]
+            activeRoutes[j] = t
+        }
+    }
+
+    return activeRoutes
+}
+
+func (self *MultiRouteSelector) GetInactiveRoutes() []Route {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    inactiveRoutes := []Route{}
+    for _, routes := range self.transportRoutes {
+        for _, route := range routes {
+            if !self.routeActive[route] {
+                inactiveRoutes = append(inactiveRoutes, route)
+            }
+        }
+    }
+
+    return inactiveRoutes
+}
+
+func (self *MultiRouteSelector) setActive(route Route, active bool) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    if _, ok := self.routeActive[route]; ok {
+        self.routeActive[route] = false
+    }
+}
+
+func (self *MultiRouteSelector) updateSendStats(route Route, sendCount int, sendByteCount ByteCount) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    stats, ok := self.routeStats[route]
+    if !ok {
+        stats = NewRouteStats()
+        self.routeStats[route] = stats
+    }
+    stats.sendCount += sendCount
+    stats.sendByteCount += sendByteCount
+}
+
+func (self *MultiRouteSelector) updateReceiveStats(route Route, receiveCount int, receiveByteCount ByteCount) {
+    self.mutex.Lock()
+    defer self.mutex.Unlock()
+
+    stats, ok := self.routeStats[route]
+    if !ok {
+        stats = NewRouteStats()
+        self.routeStats[route] = stats
+    }
+    stats.receiveCount += receiveCount
+    stats.receiveByteCount += receiveByteCount
+}
+
+// MultiRouteWriter
+func (self *MultiRouteSelector) Write(ctx context.Context, transportFrameBytes []byte, timeout time.Duration) error {
+    // write to the first channel available, in random priority
+    enterTime := time.Now()
+    for {
+        notify := self.transportUpdate.NotifyChannel()
+        activeRoutes := self.GetActiveRoutes()
+
+        // non-blocking priority 
+        for _, route := range activeRoutes {
+            select {
+            case route <- transportFrameBytes:
+                self.updateSendStats(route, 1, ByteCount(len(transportFrameBytes)))
+                return nil
+            default:
+            }
+        }
+
+        // select cases are in order:
+        // - ctx.Done
+        // - self.ctx.Done
+        // - route writes...
+        // - transport update
+        // - timeout (may not exist)
+
+        selectCases := make([]reflect.SelectCase, 0, 4 + len(activeRoutes))
+
+        // add the context done case
+        contextDoneIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(ctx.Done()),
+        })
+
+        // add the done case
+        doneIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(self.ctx.Done()),
+        })
+
+        // add the update case
+        transportUpdateIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(notify),
+        })
+
+        // add all the route
+        routeStartIndex := len(selectCases)
+        if 0 < len(activeRoutes) {
+            sendValue := reflect.ValueOf(transportFrameBytes)
+            for _, route := range activeRoutes {
+                selectCases = append(selectCases, reflect.SelectCase{
+                    Dir: reflect.SelectSend,
+                    Chan: reflect.ValueOf(route),
+                    Send: sendValue,
+                })
+            }
+        }
+
+        timeoutIndex := len(selectCases)
+        if 0 <= timeout {
+            remainingTimeout := enterTime.Add(timeout).Sub(time.Now())
+            if remainingTimeout <= 0 {
+                // add a default case
+                selectCases = append(selectCases, reflect.SelectCase{
+                    Dir: reflect.SelectDefault,
+                })
+            } else {
+                // add a timeout case
+                selectCases = append(selectCases, reflect.SelectCase{
+                    Dir: reflect.SelectRecv,
+                    Chan: reflect.ValueOf(time.After(remainingTimeout)),
+                })
+            }
+        }
+
+        // fmt.Printf("write (->%s) select from %d routes (%d transports)\n", self.destinationId, timeoutIndex - routeStartIndex, len(self.transportRoutes))
+
+
+        // note writing to a channel does not return an ok value
+        // a := time.Now()
+        chosenIndex, _, _ := reflect.Select(selectCases)
+        // d := time.Now().Sub(a)
+        // fmt.Printf("write (->%s) selected from %d routes (%.2fms)\n", self.destinationId, timeoutIndex - routeStartIndex, float64(d) / float64(time.Millisecond))
+
+        switch chosenIndex {
+        case contextDoneIndex:
+            return errors.New("Context done")
+        case doneIndex:
+            return errors.New("Done")
+        case transportUpdateIndex:
+            // new routes, try again
+        case timeoutIndex:
+            return errors.New("Timeout")
+        default:
+            // a route
+            routeIndex := chosenIndex - routeStartIndex
+            route := activeRoutes[routeIndex]
+            self.updateSendStats(route, 1, ByteCount(len(transportFrameBytes)))
+            return nil
+        }
+    }
+}
+
+// MultiRouteReader
+func (self *MultiRouteSelector) Read(ctx context.Context, timeout time.Duration) ([]byte, error) {
+    // read from the first channel available, in random priority
+    enterTime := time.Now()
+    for {
+        notify := self.transportUpdate.NotifyChannel()
+        activeRoutes := self.GetActiveRoutes()
+
+        // non-blocking priority
+        retry := false
+        for _, route := range activeRoutes {
+            select {
+            case transportFrameBytes, ok := <- route:
+                if ok {
+                    self.updateReceiveStats(route, 1, ByteCount(len(transportFrameBytes)))
+                    return transportFrameBytes, nil
+                } else {
+                    // mark the route as closed, try again
+                    self.setActive(route, false)
+                    retry = true
+                }
+            default:
+            }
+        }
+        if retry {
+            continue
+        }
+
+        // select cases are in order:
+        // - ctx.Done
+        // - self.ctx.Done
+        // - route reads...
+        // - transport update
+        // - timeout (may not exist)
+
+        selectCases := make([]reflect.SelectCase, 0, 4 + len(activeRoutes))
+
+        // add the context done case
+        contextDoneIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(self.ctx.Done()),
+        })
+
+        // add the done case
+        doneIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(self.ctx.Done()),
+        })
+
+        // add the update case
+        transportUpdateIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(notify),
+        })
+
+        // add all the route
+        routeStartIndex := len(selectCases)
+        if 0 < len(activeRoutes) {
+            for _, route := range activeRoutes {
+                selectCases = append(selectCases, reflect.SelectCase{
+                    Dir: reflect.SelectRecv,
+                    Chan: reflect.ValueOf(route),
+                })
+            }
+        }
+
+        timeoutIndex := len(selectCases)
+        if 0 <= timeout {
+            remainingTimeout := enterTime.Add(timeout).Sub(time.Now())
+            if remainingTimeout <= 0 {
+                // add a default case
+                selectCases = append(selectCases, reflect.SelectCase{
+                    Dir: reflect.SelectDefault,
+                })
+            } else {
+                // add a timeout case
+                selectCases = append(selectCases, reflect.SelectCase{
+                    Dir: reflect.SelectRecv,
+                    Chan: reflect.ValueOf(time.After(remainingTimeout)),
+                })
+            }
+        }
+
+        // a := time.Now()
+        chosenIndex, value, ok := reflect.Select(selectCases)
+        // d := time.Now().Sub(a)
+        // fmt.Printf("read (->%s) selected from %d routes (%.2fms)\n", self.destinationId, timeoutIndex - routeStartIndex, float64(d) / float64(time.Millisecond))
+
+
+        switch chosenIndex {
+        case contextDoneIndex:
+            return nil, errors.New("Context done")
+        case doneIndex:
+            return nil, errors.New("Done")
+        case transportUpdateIndex:
+            // new routes, try again
+        case timeoutIndex:
+            return nil, errors.New("Timeout")
+        default:
+            // a route
+            routeIndex := chosenIndex - routeStartIndex
+            route := activeRoutes[routeIndex]
+            if ok {
+                transportFrameBytes := value.Bytes()
+                self.updateReceiveStats(route, 1, ByteCount(len(transportFrameBytes)))
+                return transportFrameBytes, nil
+            } else {
+                // mark the route as closed, try again
+                self.setActive(route, false)
+            }
+        }
+    }
+}
+
+func (self *MultiRouteSelector) Close() {
+    self.cancel()
+}
+
+
+type RouteStats struct {
+    sendCount int
+    sendByteCount ByteCount
+    receiveCount int
+    receiveByteCount ByteCount
+}
+
+func NewRouteStats() *RouteStats {
+    return &RouteStats{
+        sendCount: 0,
+        sendByteCount: ByteCount(0),
+        receiveCount: 0,
+        receiveByteCount: ByteCount(0),
+    }
+}
+
+
+
+
+
+
+// conforms to `Transport`
+type sendGatewayTransport struct {
+	transportId Id
+}
+
+func NewSendGatewayTransport() *sendGatewayTransport {
+	return &sendGatewayTransport{
+		transportId: NewId(),
+	}
+}
+
+func (self *sendGatewayTransport) TransportId() Id {
+	return self.transportId
+}
+
+func (self *sendGatewayTransport) Priority() int {
+	return 100
+}
+
+func (self *sendGatewayTransport) CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool {
+	return true
+}
+
+func (self *sendGatewayTransport) RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32 {
+	// uniform weight
+	return 1.0 / float32(1 + len(remainingStats))
+}
+
+func (self *sendGatewayTransport) MatchesSend(destinationId Id) bool {
+	return true
+}
+
+func (self *sendGatewayTransport) MatchesReceive(destinationId Id) bool {
+	return false
+}
+
+func (self *sendGatewayTransport) Downgrade(sourceId Id) {
+	// nothing to downgrade
+}
+
+
+
+
+// conforms to `Transport`
+type receiveGatewayTransport struct {
+	transportId Id
+}
+
+func NewReceiveGatewayTransport() *receiveGatewayTransport {
+	return &receiveGatewayTransport{
+		transportId: NewId(),
+	}
+}
+
+func (self *receiveGatewayTransport) TransportId() Id {
+	return self.transportId
+}
+
+func (self *receiveGatewayTransport) Priority() int {
+	return 100
+}
+
+func (self *receiveGatewayTransport) CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool {
+	return true
+}
+
+func (self *receiveGatewayTransport) RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32 {
+	// uniform weight
+	return 1.0 / float32(1 + len(remainingStats))
+}
+
+func (self *receiveGatewayTransport) MatchesSend(destinationId Id) bool {
+	return false
+}
+
+func (self *receiveGatewayTransport) MatchesReceive(destinationId Id) bool {
+	return true
+}
+
+func (self *receiveGatewayTransport) Downgrade(sourceId Id) {
+	// nothing to downgrade
+}
+

--- a/connect/transfer_route_manager.go
+++ b/connect/transfer_route_manager.go
@@ -5,22 +5,11 @@ import (
 	"time"
 	"sync"
 	"errors"
-	// "container/heap"
-	// "sort"
-	// "math"
 	mathrand "math/rand"
 	"reflect"
-	// "crypto/hmac"
-	// "crypto/sha256"
-	// "runtime/debug"
-	// "fmt"
 	"slices"
 
 	"golang.org/x/exp/maps"
-
-	// "google.golang.org/protobuf/proto"
-
-	// "bringyour.com/protocol"
 )
 
 
@@ -837,10 +826,6 @@ func NewRouteStats() *RouteStats {
 }
 
 
-
-
-
-
 // conforms to `Transport`
 type sendGatewayTransport struct {
 	transportId Id
@@ -880,8 +865,6 @@ func (self *sendGatewayTransport) MatchesReceive(destinationId Id) bool {
 func (self *sendGatewayTransport) Downgrade(sourceId Id) {
 	// nothing to downgrade
 }
-
-
 
 
 // conforms to `Transport`

--- a/connect/transfer_route_manager_test.go
+++ b/connect/transfer_route_manager_test.go
@@ -1,0 +1,2 @@
+package connect
+

--- a/connect/transfer_route_manager_test.go
+++ b/connect/transfer_route_manager_test.go
@@ -1,2 +1,96 @@
 package connect
 
+import (
+	"context"
+    "testing"
+    "encoding/binary"
+    "bytes"
+    "time"
+
+    "github.com/go-playground/assert/v2"
+)
+
+
+func TestMultiRoute(t *testing.T) {
+	// create route manager
+	// add multiple transports and routes
+	// multi route write, write a message
+	// multi route reader, read a message
+
+	WriteTimeout := 1 * time.Second
+	ReadTimeout := 1 * time.Second
+	
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientId := NewId()
+	client := NewClientWithDefaults(ctx, clientId)
+
+	routeManager := client.RouteManager()
+
+
+	sendTransports := map[Transport][]Route{}
+	receiveTransports := map[Transport][]Route{}
+
+	transportCount := 20
+	burstSize := 2048
+	
+	multiRouteWriter := routeManager.OpenMultiRouteWriter(clientId)
+
+	multiRouteReader := routeManager.OpenMultiRouteReader(clientId)
+
+
+	for i := 0; i < transportCount; i += 1 {
+		r := make(chan []byte)
+		sendRoutes := []Route{r}
+		sendTransport := NewSendGatewayTransport()
+		receiveRoutes := []Route{r}
+		receiveTransport := NewReceiveGatewayTransport()
+
+		sendTransports[sendTransport] = sendRoutes
+		receiveTransports[receiveTransport] = receiveRoutes
+	}
+
+
+	go func() {
+		for sendTransport, sendRoutes := range sendTransports {
+			routeManager.UpdateTransport(sendTransport, sendRoutes)
+		}
+		for receiveTransport, receiveRoutes := range receiveTransports {
+			routeManager.UpdateTransport(receiveTransport, receiveRoutes)
+		}
+	}()
+
+
+	messageBytes := func(i int)([]byte) {
+		b := new(bytes.Buffer)
+		err := binary.Write(b, binary.LittleEndian, int64(i))
+		if err != nil {
+			panic(err)
+		}
+		return b.Bytes()
+	}
+
+
+	go func() {
+		for i := 0; i < burstSize; i += 1 {
+			multiRouteWriter.Write(ctx, messageBytes(i), WriteTimeout)
+		}
+	}()
+
+	for i := 0; i < burstSize; i += 1 {
+		b, err := multiRouteReader.Read(ctx, ReadTimeout)
+		assert.Equal(t, err, nil)
+		assert.Equal(t, messageBytes(i), b)
+	}
+
+		
+	for sendTransport, _ := range sendTransports {
+		routeManager.RemoveTransport(sendTransport)
+	}
+	for receiveTransport, _ := range receiveTransports {
+		routeManager.RemoveTransport(receiveTransport)
+	}
+}
+
+

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -8,6 +8,7 @@ import (
     "fmt"
     "crypto/hmac"
 	"crypto/sha256"
+	"sync"
 
 	"google.golang.org/protobuf/proto"
 
@@ -24,7 +25,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	// timeout between receives or acks
 	timeout := 30 * time.Second
 	// number of messages
-	n := 256
+	n := 16 * 1024
 
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -41,19 +42,19 @@ func TestSendReceiveSenderReset(t *testing.T) {
 
 	aConditioner.update(func() {
 		aConditioner.randomDelay = 5 * time.Second
-		aConditioner.lossProbability = 0.25
+		aConditioner.lossProbability = 0.5
 	})
 
 	bConditioner.update(func() {
 		bConditioner.randomDelay = 5 * time.Second
-		bConditioner.lossProbability = 0.25
+		bConditioner.lossProbability = 0.5
 	})
 
-	aSendTransport := newSendTransport()
-	aReceiveTransport := newReceiveTransport()
+	aSendTransport := NewSendGatewayTransport()
+	aReceiveTransport := NewReceiveGatewayTransport()
 
-	bSendTransport := newSendTransport()
-	bReceiveTransport := newReceiveTransport()
+	bSendTransport := NewSendGatewayTransport()
+	bReceiveTransport := NewReceiveGatewayTransport()
 
 	provideModes := map[protocol.ProvideMode]bool{
         protocol.ProvideMode_Network: true,
@@ -61,14 +62,12 @@ func TestSendReceiveSenderReset(t *testing.T) {
 
 
 	a := NewClientWithDefaults(ctx, aClientId)
-	aRouteManager := NewRouteManager(a)
-	aContractManager := NewContractManagerWithDefaults(a)
-	defer func() {
-		a.Cancel()
-		aRouteManager.Close()
-		aContractManager.Close()
-	}()
-	a.Setup(aRouteManager, aContractManager)
+	aRouteManager := a.RouteManager()
+	aContractManager := a.ContractManager()
+	// aRouteManager := NewRouteManager(a)
+	// aContractManager := NewContractManagerWithDefaults(a)
+	defer a.Cancel()
+	// a.Setup(aRouteManager, aContractManager)
 	go a.Run()
 
 	aRouteManager.UpdateTransport(aSendTransport, []Route{aSend})
@@ -78,14 +77,12 @@ func TestSendReceiveSenderReset(t *testing.T) {
 
 
 	b := NewClientWithDefaults(ctx, bClientId)
-	bRouteManager := NewRouteManager(b)
-	bContractManager := NewContractManagerWithDefaults(b)
-	defer func() {
-		b.Cancel()
-		bRouteManager.Close()
-		bContractManager.Close()
-	}()
-	b.Setup(bRouteManager, bContractManager)
+	bRouteManager := b.RouteManager()
+	bContractManager := b.ContractManager()
+	// bRouteManager := NewRouteManager(b)
+	// bContractManager := NewContractManagerWithDefaults(b)
+	defer b.Cancel()
+	// b.Setup(bRouteManager, bContractManager)
 	go b.Run()
 
 	bRouteManager.UpdateTransport(bSendTransport, []Route{bSend})
@@ -99,19 +96,15 @@ func TestSendReceiveSenderReset(t *testing.T) {
 
 	b.AddReceiveCallback(func(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
 		for _, frame := range frames {
-			message, err := FromFrame(frame)
-			if err != nil {
-				panic(err)
-			}
-			switch v := message.(type) {
-			case *protocol.SimpleMessage:
-				receives <- v
-			}
+			v := RequireFromFrame(frame).(*protocol.SimpleMessage)
+			receives <- v
 		}
 	})
 
 	var ackCount int
+	var waitingAckCount int
 	var receiveCount int
+	var waitingReceiveCount int
 	var receiveMessages map[string]bool
 	
 	
@@ -132,20 +125,26 @@ func TestSendReceiveSenderReset(t *testing.T) {
 			message := &protocol.SimpleMessage{
 				Content: fmt.Sprintf("hi %d", i),
 			}
-			frame, err := ToFrame(message)
-			if err != nil {
-				panic(err)
-			}
-			a.SendWithTimeout(frame, bClientId, func(err error) {
+			frame := RequireToFrame(message)
+			a.Send(frame, bClientId, func(err error) {
 				acks <- err
-			}, timeout)
+			})
 		}
 	}()
 
 	ackCount = 0
+	waitingAckCount = -1
 	receiveCount = 0
+	waitingReceiveCount = -1
 	receiveMessages = map[string]bool{}
-	for len(receiveMessages) < n || ackCount < n {
+	for receiveCount < n || ackCount < n {
+		if receiveCount < n && waitingReceiveCount < receiveCount {
+			fmt.Printf("[0] waiting for %d/%d\n", receiveCount + 1, n)
+			waitingReceiveCount = receiveCount
+		} else if ackCount < n && waitingAckCount < ackCount {
+			fmt.Printf("[0] waiting for ack %d/%d\n", ackCount + 1, n)
+		}
+
 		select {
 		case <- ctx.Done():
 			return
@@ -176,9 +175,12 @@ func TestSendReceiveSenderReset(t *testing.T) {
 
 
 	a2 := NewClientWithDefaults(ctx, aClientId)
-	a2RouteManager := NewRouteManager(a2)
-	a2ContractManager := NewContractManagerWithDefaults(a2)
-	a2.Setup(a2RouteManager, a2ContractManager)
+	a2RouteManager := a2.RouteManager()
+	a2ContractManager := a2.ContractManager()
+	// a2RouteManager := NewRouteManager(a2)
+	// a2ContractManager := NewContractManagerWithDefaults(a2)
+	// a2.Setup(a2RouteManager, a2ContractManager)
+	defer a2.Cancel()
 	go a2.Run()
 
 	a2RouteManager.UpdateTransport(aSendTransport, []Route{aSend})
@@ -204,20 +206,26 @@ func TestSendReceiveSenderReset(t *testing.T) {
 			message := &protocol.SimpleMessage{
 				Content: fmt.Sprintf("hi %d", i),
 			}
-			frame, err := ToFrame(message)
-			if err != nil {
-				panic(err)
-			}
-			a2.SendWithTimeout(frame, bClientId, func(err error) {
+			frame := RequireToFrame(message)
+			a2.Send(frame, bClientId, func(err error) {
 				acks <- err
-			}, timeout)
+			})
 		}
 	}()
 
 	ackCount = 0
+	waitingAckCount = -1
 	receiveCount = 0
+	waitingReceiveCount = -1
 	receiveMessages = map[string]bool{}
-	for len(receiveMessages) < n || ackCount < n {
+	for receiveCount < n || ackCount < n {
+		if receiveCount < n && waitingReceiveCount < receiveCount {
+			fmt.Printf("[1] waiting for %d/%d\n", receiveCount + 1, n)
+			waitingReceiveCount = receiveCount
+		} else if ackCount < n && waitingAckCount < ackCount {
+			fmt.Printf("[1] waiting for ack %d/%d\n", ackCount + 1, n)
+		}
+
 		select {
 		case <- ctx.Done():
 			return
@@ -237,6 +245,8 @@ func TestSendReceiveSenderReset(t *testing.T) {
 		found := receiveMessages[message]
 		assert.Equal(t, found, true)
 	}
+
+	fmt.Printf("[2] done\n")
 
 	assert.Equal(t, n, len(receiveMessages))
 	assert.Equal(t, n, ackCount)
@@ -365,6 +375,7 @@ type conditioner struct {
 	invertFraction float32
 	lossProbability float32
 	monitor *Monitor
+	mutex sync.Mutex
 }
 
 func newConditioner(ctx context.Context, in chan []byte) (*conditioner, chan []byte) {
@@ -381,12 +392,33 @@ func newConditioner(ctx context.Context, in chan []byte) (*conditioner, chan []b
 }
 
 func (self *conditioner) update(callback func()) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
 	callback()
 	self.monitor.NotifyAll()
 }
 
+func (self *conditioner) calcLoss() bool {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	return mathrand.Float32() < self.lossProbability
+}
+
+func (self *conditioner) calcDelay() time.Duration {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	delay := self.fixedDelay
+	if 0 < self.randomDelay {
+		delay += time.Duration(mathrand.Intn(int(self.randomDelay)))
+	}
+	return delay
+}
+
 func (self *conditioner) run(in chan []byte, out chan []byte) {
-	defer close(out)
+	// defer close(out)
 
 	for {
 		select {
@@ -399,14 +431,11 @@ func (self *conditioner) run(in chan []byte, out chan []byte) {
 				return
 			}
 
-			if mathrand.Float32() < self.lossProbability {
+			if self.calcLoss() {
 				continue
 			}
 
-			delay := self.fixedDelay
-			if 0 < self.randomDelay {
-				delay += time.Duration(mathrand.Intn(int(self.randomDelay)))
-			}
+			delay := self.calcDelay()
 
 			if delay <= 0 {
 				select {
@@ -428,97 +457,12 @@ func (self *conditioner) run(in chan []byte, out chan []byte) {
 					case out <- b:
 					}
 				}()
-			}
-
-
-				
+			}				
 		}
 	}
 }
 
 
-
-
-// conforms to `Transport`
-type sendTransport struct {
-	transportId Id
-}
-
-func newSendTransport() *sendTransport {
-	return &sendTransport{
-		transportId: NewId(),
-	}
-}
-
-func (self *sendTransport) TransportId() Id {
-	return self.transportId
-}
-
-func (self *sendTransport) Priority() int {
-	return 100
-}
-
-func (self *sendTransport) CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool {
-	return true
-}
-
-func (self *sendTransport) RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32 {
-	// uniform weight
-	return 1.0 / float32(1 + len(remainingStats))
-}
-
-func (self *sendTransport) MatchesSend(destinationId Id) bool {
-	return true
-}
-
-func (self *sendTransport) MatchesReceive(destinationId Id) bool {
-	return false
-}
-
-func (self *sendTransport) Downgrade(sourceId Id) {
-	// nothing to downgrade
-}
-
-
-// conforms to `Transport`
-type receiveTransport struct {
-	transportId Id
-}
-
-func newReceiveTransport() *receiveTransport {
-	return &receiveTransport{
-		transportId: NewId(),
-	}
-}
-
-func (self *receiveTransport) TransportId() Id {
-	return self.transportId
-}
-
-func (self *receiveTransport) Priority() int {
-	return 100
-}
-
-func (self *receiveTransport) CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool {
-	return true
-}
-
-func (self *receiveTransport) RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32 {
-	// uniform weight
-	return 1.0 / float32(1 + len(remainingStats))
-}
-
-func (self *receiveTransport) MatchesSend(destinationId Id) bool {
-	return false
-}
-
-func (self *receiveTransport) MatchesReceive(destinationId Id) bool {
-	return true
-}
-
-func (self *receiveTransport) Downgrade(sourceId Id) {
-	// nothing to downgrade
-}
 
 
 

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -441,10 +441,17 @@ func (self *conditioner) run(in chan []byte, out chan []byte) {
 
 // conforms to `Transport`
 type sendTransport struct {
+	transportId Id
 }
 
 func newSendTransport() *sendTransport {
-	return &sendTransport{}
+	return &sendTransport{
+		transportId: NewId(),
+	}
+}
+
+func (self *sendTransport) TransportId() Id {
+	return self.transportId
 }
 
 func (self *sendTransport) Priority() int {
@@ -475,10 +482,17 @@ func (self *sendTransport) Downgrade(sourceId Id) {
 
 // conforms to `Transport`
 type receiveTransport struct {
+	transportId Id
 }
 
 func newReceiveTransport() *receiveTransport {
-	return &receiveTransport{}
+	return &receiveTransport{
+		transportId: NewId(),
+	}
+}
+
+func (self *receiveTransport) TransportId() Id {
+	return self.transportId
 }
 
 func (self *receiveTransport) Priority() int {

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -24,7 +24,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	// timeout between receives or acks
 	timeout := 30 * time.Second
 	// number of messages
-	n := 10
+	n := 1000
 
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -41,12 +41,12 @@ func TestSendReceiveSenderReset(t *testing.T) {
 
 	aConditioner.update(func() {
 		aConditioner.randomDelay = 5 * time.Second
-		aConditioner.lossProbability = 0.1
+		aConditioner.lossProbability = 0.4
 	})
 
 	bConditioner.update(func() {
 		bConditioner.randomDelay = 5 * time.Second
-		bConditioner.lossProbability = 0.1
+		bConditioner.lossProbability = 0.4
 	})
 
 	aSendTransport := newSendTransport()
@@ -68,8 +68,8 @@ func TestSendReceiveSenderReset(t *testing.T) {
 		aRouteManager.Close()
 		aContractManager.Close()
 	}()
-
-	go a.Run(aRouteManager, aContractManager)
+	a.Setup(aRouteManager, aContractManager)
+	go a.Run()
 
 	aRouteManager.UpdateTransport(aSendTransport, []Route{aSend})
 	aRouteManager.UpdateTransport(aReceiveTransport, []Route{aReceive})
@@ -85,8 +85,8 @@ func TestSendReceiveSenderReset(t *testing.T) {
 		bRouteManager.Close()
 		bContractManager.Close()
 	}()
-
-	go b.Run(bRouteManager, bContractManager)
+	b.Setup(bRouteManager, bContractManager)
+	go b.Run()
 
 	bRouteManager.UpdateTransport(bSendTransport, []Route{bSend})
 	bRouteManager.UpdateTransport(bReceiveTransport, []Route{bReceive})
@@ -111,7 +111,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	})
 
 	var ackCount int
-	// var receiveCount int
+	var receiveCount int
 	var receiveMessages map[string]bool
 	
 	
@@ -143,7 +143,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	}()
 
 	ackCount = 0
-	// receiveCount = 0
+	receiveCount = 0
 	receiveMessages = map[string]bool{}
 	for len(receiveMessages) < n || ackCount < n {
 		select {
@@ -151,8 +151,8 @@ func TestSendReceiveSenderReset(t *testing.T) {
 			return
 		case message := <- receives:
 			receiveMessages[message.Content] = true
-			// assert.Equal(t, fmt.Sprintf("hi %d", receiveCount), message.Content)
-			// receiveCount += 1
+			assert.Equal(t, fmt.Sprintf("hi %d", receiveCount), message.Content)
+			receiveCount += 1
 		case err := <- acks:
 			assert.Equal(t, err, nil)
 			ackCount += 1
@@ -178,8 +178,8 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	a2 := NewClientWithDefaults(ctx, aClientId)
 	a2RouteManager := NewRouteManager(a2)
 	a2ContractManager := NewContractManagerWithDefaults(a2)
-
-	go a2.Run(a2RouteManager, a2ContractManager)
+	a2.Setup(a2RouteManager, a2ContractManager)
+	go a2.Run()
 
 	a2RouteManager.UpdateTransport(aSendTransport, []Route{aSend})
 	a2RouteManager.UpdateTransport(aReceiveTransport, []Route{aReceive})
@@ -215,7 +215,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	}()
 
 	ackCount = 0
-	// receiveCount = 0
+	receiveCount = 0
 	receiveMessages = map[string]bool{}
 	for len(receiveMessages) < n || ackCount < n {
 		select {
@@ -223,8 +223,8 @@ func TestSendReceiveSenderReset(t *testing.T) {
 			return
 		case message := <- receives:
 			receiveMessages[message.Content] = true
-			// assert.Equal(t, fmt.Sprintf("hi %d", receiveCount), message.Content)
-			// receiveCount += 1
+			assert.Equal(t, fmt.Sprintf("hi %d", receiveCount), message.Content)
+			receiveCount += 1
 		case err := <- acks:
 			assert.Equal(t, err, nil)
 			ackCount += 1

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -24,7 +24,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	// timeout between receives or acks
 	timeout := 30 * time.Second
 	// number of messages
-	n := 1000
+	n := 256
 
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -41,12 +41,12 @@ func TestSendReceiveSenderReset(t *testing.T) {
 
 	aConditioner.update(func() {
 		aConditioner.randomDelay = 5 * time.Second
-		aConditioner.lossProbability = 0.4
+		aConditioner.lossProbability = 0.25
 	})
 
 	bConditioner.update(func() {
 		bConditioner.randomDelay = 5 * time.Second
-		bConditioner.lossProbability = 0.4
+		bConditioner.lossProbability = 0.25
 	})
 
 	aSendTransport := newSendTransport()
@@ -157,7 +157,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 			assert.Equal(t, err, nil)
 			ackCount += 1
 		case <- time.After(timeout):
-			t.FailNow()
+			t.Fatal("Timeout.")
 		}
 	}
 	for i := 0; i < n; i += 1 {
@@ -229,7 +229,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 			assert.Equal(t, err, nil)
 			ackCount += 1
 		case <- time.After(timeout):
-			t.FailNow()
+			t.Fatal("Timeout.")
 		}
 	}
 	for i := 0; i < n; i += 1 {
@@ -505,5 +505,6 @@ func (self *receiveTransport) MatchesReceive(destinationId Id) bool {
 func (self *receiveTransport) Downgrade(sourceId Id) {
 	// nothing to downgrade
 }
+
 
 

--- a/connect/transport.go
+++ b/connect/transport.go
@@ -215,8 +215,6 @@ func (self *PlatformTransport) Run(routeManager *RouteManager) {
             }
         }
 
-        // ws.SetDeadline(time.Time{})
-
         func() {
             handleCtx, handleCancel := context.WithCancel(self.ctx)
 
@@ -244,9 +242,7 @@ func (self *PlatformTransport) Run(routeManager *RouteManager) {
                     }
 
                     close(send)
-                    // close(receive)
                 }()
-
             }()
 
             go func() {
@@ -301,7 +297,6 @@ func (self *PlatformTransport) Run(routeManager *RouteManager) {
                         return
                     }
 
-
                     transportLog("READ MESSAGE\n")
 
                     switch messageType {
@@ -310,7 +305,6 @@ func (self *PlatformTransport) Run(routeManager *RouteManager) {
                             // ping
                             continue
                         }
-
 
                         // fmt.Printf("transport read message ->%s\n", self.auth.ClientId)
 

--- a/connect/transport.go
+++ b/connect/transport.go
@@ -37,7 +37,7 @@ const DefaultWsHandshakeTimeout = 2 * time.Second
 const DefaultAuthTimeout = 2 * time.Second
 const DefaultReconnectTimeout = 2 * time.Second
 const DefaultPingTimeout = 5 * time.Second
-const DefaultWriteTimeout = 30 * time.Second
+const DefaultWriteTimeout = 5 * time.Second
 const DefaultReadTimeout = 2 * DefaultPingTimeout
 
 
@@ -252,6 +252,7 @@ func (self *PlatformTransport) Run(routeManager *RouteManager) {
                         // transportLog("!!!! WRITE MESSAGE %s\n", message)
                         ws.SetWriteDeadline(time.Now().Add(self.settings.WriteTimeout))
                         if err := ws.WriteMessage(websocket.BinaryMessage, message); err != nil {
+                            // fmt.Printf("ws write error\n")
                             transportLog("Write message error %s\n", err)
                             return
                         }

--- a/connect/transport.go
+++ b/connect/transport.go
@@ -29,12 +29,12 @@ const BUFFER = 1
 // add the source ip as the X-Extender header
 
 
-const DefaultHttpConnectTimeout = 5 * time.Second
-const DefaultWsHandshakeTimeout = 5 * time.Second
-const DefaultAuthTimeout = 5 * time.Second
-const DefaultReconnectTimeout = 5 * time.Second
-const DefaultPingTimeout = 15 * time.Second
-const DefaultWriteTimeout = 15 * time.Second
+const DefaultHttpConnectTimeout = 2 * time.Second
+const DefaultWsHandshakeTimeout = 2 * time.Second
+const DefaultAuthTimeout = 2 * time.Second
+const DefaultReconnectTimeout = 2 * time.Second
+const DefaultPingTimeout = 5 * time.Second
+const DefaultWriteTimeout = 30 * time.Second
 const DefaultReadTimeout = 2 * DefaultPingTimeout
 
 

--- a/connect/transport.go
+++ b/connect/transport.go
@@ -223,8 +223,10 @@ func (self *PlatformTransport) Run(routeManager *RouteManager) {
             send := make(chan []byte, TransportBufferSize)
             receive := make(chan []byte, TransportBufferSize)
 
-            sendTransport := newPlatformSendTransport()
-            receiveTransport := newPlatformReceiveTransport()
+            // the platform can route any destination,
+            // since every client has a platform transport
+            sendTransport := NewSendGatewayTransport()
+            receiveTransport := NewReceiveGatewayTransport()
 
             routeManager.UpdateTransport(sendTransport, []Route{send})
             routeManager.UpdateTransport(receiveTransport, []Route{receive})
@@ -340,90 +342,6 @@ func (self *PlatformTransport) Run(routeManager *RouteManager) {
 
 func (self *PlatformTransport) Close() {
     self.cancel()
-}
-
-
-// conforms to `connect.Transport`
-type platformSendTransport struct {
-    transportId Id
-}
-
-func newPlatformSendTransport() *platformSendTransport {
-    return &platformSendTransport{
-        transportId: NewId(),
-    }
-}
-
-func (self *platformSendTransport) TransportId() Id {
-    return self.transportId
-}
-
-func (self *platformSendTransport) Priority() int {
-    return 100
-}
-
-func (self *platformSendTransport) CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool {
-    return true
-}
-
-func (self *platformSendTransport) RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32 {
-    // uniform weight
-    return 1.0 / float32(1 + len(remainingStats))
-}
-
-func (self *platformSendTransport) MatchesSend(destinationId Id) bool {
-    // the platform can route any destination,
-    // since every client has a platform transport
-    return true
-}
-
-func (self *platformSendTransport) MatchesReceive(destinationId Id) bool {
-    return false
-}
-
-func (self *platformSendTransport) Downgrade(sourceId Id) {
-    // nothing to downgrade
-}
-
-
-// conforms to `connect.Transport`
-type platformReceiveTransport struct {
-    transportId Id
-}
-
-func newPlatformReceiveTransport() *platformReceiveTransport {
-    return &platformReceiveTransport{
-        transportId: NewId(),
-    }
-}
-
-func (self *platformReceiveTransport) TransportId() Id {
-    return self.transportId
-}
-
-func (self *platformReceiveTransport) Priority() int {
-    return 100
-}
-
-func (self *platformReceiveTransport) CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool {
-    return true
-}
-
-func (self *platformReceiveTransport) RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32 {
-    // uniform weight
-    return 1.0 / float32(1 + len(remainingStats))
-}
-
-func (self *platformReceiveTransport) MatchesSend(destinationId Id) bool {
-    return false
-}
-
-func (self *platformReceiveTransport) MatchesReceive(destinationId Id) bool {
-    return true
-}
-
-func (self *platformReceiveTransport) Downgrade(sourceId Id) {
-    // nothing to downgrade
 }
 
 

--- a/connectctl/go.mod
+++ b/connectctl/go.mod
@@ -1,6 +1,6 @@
 module bringyour.com/connectctl
 
-go 1.21.0
+go 1.22.0
 
 replace bringyour.com/connect v0.0.0 => ../connect
 

--- a/connectctl/main.go
+++ b/connectctl/main.go
@@ -21,7 +21,7 @@ import (
     "net/http"
     "log"
     "encoding/json"
-    "encoding/base64"
+    // "encoding/base64"
     "bytes"
 
     // "golang.org/x/exp/maps"
@@ -78,9 +78,12 @@ Usage:
     connectctl client-id [--api_url=<api_url>] --jwt=<jwt> 
     connectctl send [--connect_url=<connect_url>] --jwt=<jwt>
         --destination_id=<destination_id>
-        [<message>]
+        <message>
+        [--message_count=<message_count>]
+        [--instance_id=<instance_id>]
     connectctl sink [--connect_url=<connect_url>] --jwt=<jwt>
         [--message_count=<message_count>]
+        [--instance_id=<instance_id>]
     
 Options:
     -h --help                        Show this screen.
@@ -94,7 +97,8 @@ Options:
     --code=<code>
     --jwt=<jwt>                      Your platform JWT.
     --destination_id=<destination_id>   Destination client_id
-    --message_count=<message_count>  Print this many messages then exit.`,
+    --message_count=<message_count>  Print this many messages then exit.
+    --instance_id=<instance_id>      Set the client instance id.`,
         DefaultApiUrl,
         DefaultConnectUrl,
     )
@@ -139,6 +143,14 @@ func expandByJwt(result map[string]any) {
 
         for claimKey, claimValue := range claims {
             result[fmt.Sprintf("by_jwt_%s", claimKey)] = claimValue
+        }
+    }
+    if jwt, ok := result["by_client_jwt"]; ok {
+        claims := gojwt.MapClaims{}
+        gojwt.NewParser().ParseUnverified(jwt.(string), claims)
+
+        for claimKey, claimValue := range claims {
+            result[fmt.Sprintf("by_client_jwt_%s", claimKey)] = claimValue
         }
     }
     for _, value := range result {
@@ -388,7 +400,7 @@ func clientId(opts docopt.Opts) {
 
     jwt, _ := opts.String("--jwt")
 
-    bearer := base64.StdEncoding.EncodeToString([]byte(jwt))
+    bearer := []byte(jwt)
 
     timeout := 5 * time.Second
 
@@ -428,7 +440,7 @@ func clientId(opts docopt.Opts) {
         return
     }
 
-    // fmt.Printf("response: %s\n", resBody)
+    fmt.Printf("response: %s\n", resBody)
 
     result := map[string]any{}
     err = json.Unmarshal(resBody, &result)
@@ -480,8 +492,28 @@ func send(opts docopt.Opts) {
         fmt.Printf("Invalid destination_id (%s).\n", err)
         return
     }
+
+    instanceIdStr, err := opts.String("--instance_id")
+    var instanceId connect.Id
+    if err == nil {
+        instanceId, err = connect.ParseId(instanceIdStr)
+        if err != nil {
+            fmt.Printf("Invalid instance_id (%s).\n", err)
+            return
+        }
+    } else {
+        instanceId = connect.NewId()
+    }
+
+    fmt.Printf("instance_id: %s\n", instanceId.String())
+
     
     messageContent, _ := opts.String("<message>")
+
+    messageCount, err := opts.Int("--message_count")
+    if err != nil {
+        messageCount = 1
+    }
 
     timeout := 30 * time.Second
 
@@ -495,10 +527,14 @@ func send(opts docopt.Opts) {
     )
     defer client.Close()
 
+
+    client.SetInstanceId(instanceId)
+    
+
     routeManager := connect.NewRouteManager(client)
     contractManager := connect.NewContractManagerWithDefaults(client)
-
-    go client.Run(routeManager, contractManager)
+    client.Setup(routeManager, contractManager)
+    go client.Run()
 
     auth := &connect.ClientAuth{
         ByJwt: jwt,
@@ -521,30 +557,40 @@ func send(opts docopt.Opts) {
     contractManager.SetProvideModes(provideModes)
 
 
+    // FIXME break into 2k chunks?
     acks := make(chan error)
+    go func() {
+        for i := 0; i < messageCount; i += 1 {
+            var content string
+            if 0 < messageCount {
+                content = fmt.Sprintf("[%d] %s", i, messageContent)
+            } else {
+                content = messageContent
+            }
+            message := &protocol.SimpleMessage{
+                Content: content,
+            }
 
-    // FIXME break into 2k chunks
-    message := &protocol.SimpleMessage{
-        Content: messageContent,
-    }
-
-    client.Send(
-        connect.RequireToFrame(message),
-        destinationId,
-        func(err error) {
-            acks <- err
-        },
-    )
-
-    select {
-    case err := <- acks:
-        if err == nil {
-            fmt.Printf("Message acked.")
-        } else {
-            fmt.Printf("Message not acked (%s).", err)
+            client.Send(
+                connect.RequireToFrame(message),
+                destinationId,
+                func(err error) {
+                    acks <- err
+                },
+            ) 
         }
-    case <- time.After(timeout):
-        fmt.Printf("Message not acked (timeout).")
+    }()
+    for i := 0; i < messageCount; i += 1 {
+        select {
+        case err := <- acks:
+            if err == nil {
+                fmt.Printf("Message acked.\n")
+            } else {
+                fmt.Printf("Message not acked (%s).\n", err)
+            }
+        case <- time.After(timeout):
+            fmt.Printf("Message not acked (timeout).\n")
+        }
     }
 }
 
@@ -588,6 +634,20 @@ func sink(opts docopt.Opts) {
         messageCount = -1
     }
 
+    instanceIdStr, err := opts.String("--instance_id")
+    var instanceId connect.Id
+    if err == nil {
+        instanceId, err = connect.ParseId(instanceIdStr)
+        if err != nil {
+            fmt.Printf("Invalid instance_id (%s).\n", err)
+            return
+        }
+    } else {
+        instanceId = connect.NewId()
+    }
+
+    fmt.Printf("instance_id: %s\n", instanceId.String())
+
 
     cancelCtx, cancel := context.WithCancel(context.Background())
     defer cancel()
@@ -598,15 +658,20 @@ func sink(opts docopt.Opts) {
     )
     defer client.Close()
 
+    client.SetInstanceId(instanceId)
+
     routeManager := connect.NewRouteManager(client)
     contractManager := connect.NewContractManagerWithDefaults(client)
+
+    client.Setup(routeManager, contractManager)
+    go client.Run()
+
 
     provideModes := map[protocol.ProvideMode]bool{
         protocol.ProvideMode_Network: true,
     }
     contractManager.SetProvideModes(provideModes)
 
-    go client.Run(routeManager, contractManager)
 
     auth := &connect.ClientAuth{
         ByJwt: jwt,
@@ -643,7 +708,7 @@ func sink(opts docopt.Opts) {
     for i := 0; messageCount < 0 || i < messageCount; i += 1 {
         select {
         case receive := <- receives:
-            fmt.Printf("GOT A MESSAGE %s %s %s\n", receive.sourceId, receive.frames, receive.provideMode)
+            fmt.Printf("[%s %s] %s\n", receive.sourceId, receive.provideMode, receive.frames)
         }
     }
 }

--- a/connectctl/main.go
+++ b/connectctl/main.go
@@ -515,6 +515,9 @@ func send(opts docopt.Opts) {
         messageCount = 1
     }
 
+    // need at least one. Use more for testing.
+    transportCount := 4
+
     timeout := 30 * time.Second
 
 
@@ -541,14 +544,15 @@ func send(opts docopt.Opts) {
         InstanceId: client.InstanceId(),
         AppVersion: fmt.Sprintf("connectctl %s", ConnectCtlVersion),
     }
-    platformTransport := connect.NewPlatformTransportWithDefaults(
-        cancelCtx,
-        fmt.Sprintf("%s/", connectUrl),
-        auth,
-    )
-    defer platformTransport.Close()
-
-    go platformTransport.Run(routeManager)
+    for i := 0; i < transportCount; i += 1 {
+        platformTransport := connect.NewPlatformTransportWithDefaults(
+            cancelCtx,
+            fmt.Sprintf("%s/", connectUrl),
+            auth,
+        )
+        defer platformTransport.Close()
+        go platformTransport.Run(routeManager)
+    }
 
 
     provideModes := map[protocol.ProvideMode]bool{
@@ -634,6 +638,8 @@ func sink(opts docopt.Opts) {
         messageCount = -1
     }
 
+    transportCount := 4
+
     instanceIdStr, err := opts.String("--instance_id")
     var instanceId connect.Id
     if err == nil {
@@ -678,14 +684,15 @@ func sink(opts docopt.Opts) {
         InstanceId: client.InstanceId(),
         AppVersion: fmt.Sprintf("connectctl %s", ConnectCtlVersion),
     }
-    platformTransport := connect.NewPlatformTransportWithDefaults(
-        cancelCtx,
-        fmt.Sprintf("%s/", connectUrl),
-        auth,
-    )
-    defer platformTransport.Close()
-
-    go platformTransport.Run(routeManager)
+    for i := 0; i < transportCount; i += 1 {
+        platformTransport := connect.NewPlatformTransportWithDefaults(
+            cancelCtx,
+            fmt.Sprintf("%s/", connectUrl),
+            auth,
+        )
+        defer platformTransport.Close()
+        go platformTransport.Run(routeManager)
+    }
 
     type Receive struct {
         sourceId connect.Id

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module bringyour.com/connect/provider
 
-go 1.21.0
+go 1.22.0
 
 replace bringyour.com/connect v0.0.0 => ../connect
 

--- a/provider/main.go
+++ b/provider/main.go
@@ -117,7 +117,8 @@ func provide(opts docopt.Opts) {
 
     routeManager := connect.NewRouteManager(connectClient)
     contractManager := connect.NewContractManagerWithDefaults(connectClient)
-    go connectClient.Run(routeManager, contractManager)
+    connectClient.Setup(routeManager, contractManager)
+    go connectClient.Run()
 
     auth := &connect.ClientAuth{
         ByJwt: byClientJwt,

--- a/test-ip-local/go.mod
+++ b/test-ip-local/go.mod
@@ -1,6 +1,6 @@
 module bringyour.com/connect/test-ip-local
 
-go 1.21.0
+go 1.22.0
 
 replace bringyour.com/connect v0.0.0 => ../connect
 


### PR DESCRIPTION
Fix a number of concurrency, ack-related, and route issues. This is done in tandem with fixing the BringYour exchange, which hosts the server side of connect as a horizontally distributed system.

- potential deadlock in buffer.Pack and buffer.Ack that can cause acks to not submit if there is a pending pack
- acks were not always echoed for resends. Additionally the ack head should be echoed for efficiency.
- routes use Transport as a key. Multiple empty Transport structs would lead to incorrect behavior, due to this strange behavior in Go: https://github.com/golang/go/issues/65878
- fix PeekLast issues with transfer queue
- fix -race issues
- move RouteManager and ContractManager as owned by Client, which clarifies the expected 1:1 relationship
