### PR TITLE
Multi unat - use a window of clients for better aggregate performance

### DIFF
--- a/api/bringyour.yml
+++ b/api/bringyour.yml
@@ -501,13 +501,13 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "#/components/schemas/FindActiveProvidersArgs"
+                            $ref: "#/components/schemas/FindProvidersArgs"
             responses:
                 "200":
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/FindActiveProvidersResult"
+                                $ref: "#/components/schemas/FindProvidersResult"
 
     /network/find-providers2:
         post:
@@ -523,15 +523,15 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "#/components/schemas/FindActiveProviders2Args"
+                            $ref: "#/components/schemas/FindProviders2Args"
             responses:
                 "200":
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/FindActiveProviders2Result"
+                                $ref: "#/components/schemas/FindProviders2Result"
 
-    /network/find-providers-spec:
+    /network/create-provider-spec:
         post:
             description: |
                 Create a spec object for `find-providers2` using a description
@@ -543,13 +543,13 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "#/components/schemas/FindActiveProvidersSpecArgs"
+                            $ref: "#/components/schemas/CreateProviderSpecArgs"
             responses:
                 "200":
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/FindActiveProvidersSpecResult"
+                                $ref: "#/components/schemas/CreateProviderSpecResult"
 
     /wallet/balance:
         get:
@@ -1408,6 +1408,11 @@ components:
                 device_spec:
                     description: If this is a new device, sets the device spec.
                     type: string
+                derived_client_id:
+                    description: udid. Optional. |
+                        The client that the new client is derived from. 
+                        If this is called with a client jwt, the derived client id is inferred from the jwt.
+                    type: string
 
         AuthNetworkClientResult:
             type: object
@@ -1582,25 +1587,11 @@ components:
         FindLocationsResult:
             type: object
             properties:
-                intents:
-                    type: object
-                    properties:
-                        name:
-                            type: string
-                        # specs can be directly passed to `find-providers2` to enumerate clients for this result
-                        specs:
-                            type: array
-                            items:
-                                type: object
-                                properties:
-                                    location_id:
-                                        description: udid
-                                        type: string
-                                    location_group_id:
-                                        description: udid
-                                        type: string
-                                    client_id:
-                                        description: udid
+                # specs can be directly passed to `find-providers2` to enumerate clients for this result
+                specs:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ProviderSpec"
                 groups:
                     type: array
                     items:
@@ -1665,7 +1656,7 @@ components:
                             device_name:
                                 type: string
 
-        FindActiveProvidersArgs:
+        FindProvidersArgs:
             type: object
             properties:
                 location_id:
@@ -1682,7 +1673,7 @@ components:
                         description: udid
                         type: string
 
-        FindActiveProvidersResult:
+        FindProvidersResult:
             type: object
             properties:
                 client_ids:
@@ -1703,7 +1694,7 @@ components:
                 client_id:
                     description: udid
 
-        FindActiveProviders2Args:
+        FindProviders2Args:
             type: object
             properties:
                 # specs are unioned (or)
@@ -1719,12 +1710,11 @@ components:
                         description: udid
                         type: string
 
-        FindActiveProviders2Result:
+        FindProviders2Result:
             type: object
             properties:
-                client_ids:
+                providers:
                     type: array
-                    # FIXME initial stats
                     items:
                         type: object
                         properites:
@@ -1734,14 +1724,14 @@ components:
                             estimated_bytes_per_second:
                                 type: integer
 
-        FindActiveProvidersSpecArgs:
+        CreateProviderSpecArgs:
             type: object
             properties:
                 query:
                     description: description of the intended use of the connection
                     type: string
 
-        FindActiveProvidersSpecResult:
+        CreateProviderSpecResult:
             type: object
             properties:
                 # specs are unioned (or)

--- a/api/bringyour.yml
+++ b/api/bringyour.yml
@@ -1593,6 +1593,16 @@ components:
                                 type: integer
                             match_distance:
                                 type: integer
+                devices:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            client_id:
+                                description: udid
+                                type: string
+                            device_name:
+                                type: string
 
         FindActiveProvidersArgs:
             type: object

--- a/api/bringyour.yml
+++ b/api/bringyour.yml
@@ -470,7 +470,7 @@ paths:
     /network/find-locations:
         post:
             description: |
-                Search for locations and groups that match a query,
+                Search for locations, groups, and devices that match a query,
                 regardless of whether an providers are active.
             operationId: Network Find Locations
             security: []
@@ -508,6 +508,48 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/FindActiveProvidersResult"
+
+    /network/find-providers2:
+        post:
+            description: |
+                Randomly sample providers for locations, groups, or devices,
+                which are active and in good health.
+                This allows random iteration by using the exclude input to mark
+                visited providers.
+            operationId: Network Find Providers 2
+            security: []
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/FindActiveProviders2Args"
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FindActiveProviders2Result"
+
+    /network/find-providers-spec:
+        post:
+            description: |
+                Create a spec object for `find-providers2` using a description
+                of the intended use of the network.
+            operationId: Network Find Providers Spec
+            security: []
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/FindActiveProvidersSpecArgs"
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FindActiveProvidersSpecResult"
 
     /wallet/balance:
         get:
@@ -1540,6 +1582,25 @@ components:
         FindLocationsResult:
             type: object
             properties:
+                intents:
+                    type: object
+                    properties:
+                        name:
+                            type: string
+                        # specs can be directly passed to `find-providers2` to enumerate clients for this result
+                        specs:
+                            type: array
+                            items:
+                                type: object
+                                properties:
+                                    location_id:
+                                        description: udid
+                                        type: string
+                                    location_group_id:
+                                        description: udid
+                                        type: string
+                                    client_id:
+                                        description: udid
                 groups:
                     type: array
                     items:
@@ -1629,6 +1690,65 @@ components:
                     items:
                         description: udid
                         type: string
+
+        ProviderSpec:
+            type: object
+            properties:
+                location_id:
+                    description: udid
+                    type: string
+                location_group_id:
+                    description: udid
+                    type: string
+                client_id:
+                    description: udid
+
+        FindActiveProviders2Args:
+            type: object
+            properties:
+                # specs are unioned (or)
+                specs:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ProviderSpec"
+                count:
+                    type: integer
+                exclude_client_ids:
+                    type: array
+                    items:
+                        description: udid
+                        type: string
+
+        FindActiveProviders2Result:
+            type: object
+            properties:
+                client_ids:
+                    type: array
+                    # FIXME initial stats
+                    items:
+                        type: object
+                        properites:
+                            client_id:
+                                description: udid
+                                type: string
+                            estimated_bytes_per_second:
+                                type: integer
+
+        FindActiveProvidersSpecArgs:
+            type: object
+            properties:
+                query:
+                    description: description of the intended use of the connection
+                    type: string
+
+        FindActiveProvidersSpecResult:
+            type: object
+            properties:
+                # specs are unioned (or)
+                specs:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ProviderSpec"
 
         WalletBalanceResult:
             type: object

--- a/connect/api.go
+++ b/connect/api.go
@@ -412,7 +412,7 @@ func post[R any](ctx context.Context, url string, args any, byJwt string, result
 		}
 	}
 
-	apiLog("REQUEST BODY BYTES: %s", string(requestBodyBytes))
+	// apiLog("REQUEST BODY BYTES: %s", string(requestBodyBytes))
 
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(requestBodyBytes))
@@ -424,11 +424,11 @@ func post[R any](ctx context.Context, url string, args any, byJwt string, result
 
 	req.Header.Add("Content-Type", "text/json")
 
-	apiLog("BY JWT IS \"%s\"", byJwt)
+	// apiLog("BY JWT IS \"%s\"", byJwt)
 
 	if byJwt != "" {
 		auth := fmt.Sprintf("Bearer %s", byJwt)
-		apiLog("AUTH: \"%s\"", auth)
+		// apiLog("AUTH: \"%s\"", auth)
 		req.Header.Add("Authorization", auth)
 	}
 
@@ -436,7 +436,7 @@ func post[R any](ctx context.Context, url string, args any, byJwt string, result
 	client := defaultClient()
 	r, err := client.Do(req)
 	if err != nil {
-		apiLog("REQUEST ERROR %s", err)
+		// apiLog("REQUEST ERROR %s", err)
 		var empty R
 		callback.Result(empty, err)
 		return empty, err
@@ -448,7 +448,7 @@ func post[R any](ctx context.Context, url string, args any, byJwt string, result
 	if http.StatusOK != r.StatusCode {
 		// the response body is the error message
 		errorMessage := strings.TrimSpace(string(responseBodyBytes))
-		apiLog("RESPONSE ERROR %s: %s", r.Status, errorMessage)
+		// apiLog("RESPONSE ERROR %s: %s", r.Status, errorMessage)
 		err = errors.New(errorMessage)
 		callback.Result(result, err)
 		return result, err
@@ -459,11 +459,11 @@ func post[R any](ctx context.Context, url string, args any, byJwt string, result
 		return result, err
 	}
 
-	apiLog("GOT API RESPONSE BODY: %s", string(responseBodyBytes))
+	// apiLog("GOT API RESPONSE BODY: %s", string(responseBodyBytes))
 
 	err = json.Unmarshal(responseBodyBytes, &result)
 	if err != nil {
-		apiLog("UNMARSHAL ERROR %s", err)
+		// apiLog("UNMARSHAL ERROR %s", err)
 		var empty R
 		callback.Result(empty, err)
 		return empty, err
@@ -484,11 +484,11 @@ func get[R any](ctx context.Context, url string, byJwt string, result R, callbac
 
 	req.Header.Add("Content-Type", "text/json")
 
-	apiLog("BY JWT IS \"%s\"", byJwt)
+	// apiLog("BY JWT IS \"%s\"", byJwt)
 
 	if byJwt != "" {
 		auth := fmt.Sprintf("Bearer %s", byJwt)
-		apiLog("AUTH: \"%s\"", auth)
+		// apiLog("AUTH: \"%s\"", auth)
 		req.Header.Add("Authorization", auth)
 	}
 
@@ -496,7 +496,7 @@ func get[R any](ctx context.Context, url string, byJwt string, result R, callbac
 	client := defaultClient()
 	r, err := client.Do(req)
 	if err != nil {
-		apiLog("REQUEST ERROR %s", err)
+		// apiLog("REQUEST ERROR %s", err)
 		var empty R
 		callback.Result(empty, err)
 		return empty, err
@@ -505,11 +505,11 @@ func get[R any](ctx context.Context, url string, byJwt string, result R, callbac
 	responseBodyBytes, err := io.ReadAll(r.Body)
 	r.Body.Close()
 
-	apiLog("GOT API RESPONSE BODY: %s", string(responseBodyBytes))
+	// apiLog("GOT API RESPONSE BODY: %s", string(responseBodyBytes))
 
 	err = json.Unmarshal(responseBodyBytes, &result)
 	if err != nil {
-		apiLog("UNMARSHAL ERROR %s", err)
+		// apiLog("UNMARSHAL ERROR %s", err)
 		var empty R
 		callback.Result(empty, err)
 		return empty, err

--- a/connect/api.go
+++ b/connect/api.go
@@ -372,7 +372,7 @@ type FindProviders2Result struct {
 
 type FindProvidersProvider struct {
 	ClientId Id `json:"client_id"`
-	EstimatedBytesPerSecond int `json:"estimated_bytes_per_second"`
+	EstimatedBytesPerSecond ByteCount `json:"estimated_bytes_per_second"`
 }
 
 func (self *BringYourApi) FindProviders2(findProviders2 *FindProviders2Args, callback FindProviders2Callback) {

--- a/connect/connect.go
+++ b/connect/connect.go
@@ -5,6 +5,7 @@ import (
 	// "log"
 	"fmt"
 	"encoding/hex"
+	"bytes"
 
 	"github.com/oklog/ulid/v2"
 )
@@ -60,6 +61,30 @@ func (self Id) Bytes() []byte {
 
 func (self Id) String() string {
 	return encodeUuid(self)
+}
+
+
+func (self *Id) MarshalJSON() ([]byte, error) {
+	var buf [16]byte
+	copy(buf[0:16], self[0:16])
+	var buff bytes.Buffer
+	buff.WriteByte('"')
+	buff.WriteString(encodeUuid(buf))
+	buff.WriteByte('"')
+	b := buff.Bytes()
+	return b, nil
+}
+
+func (self *Id) UnmarshalJSON(src []byte) error {
+	if len(src) != 38 {
+		return fmt.Errorf("invalid length for UUID: %v", len(src))
+	}
+	buf, err := parseUuid(string(src[1 : len(src)-1]))
+	if err != nil {
+		return err
+	}
+	*self = buf
+	return nil
 }
 
 

--- a/connect/connect.go
+++ b/connect/connect.go
@@ -12,7 +12,7 @@ import (
 
 
 // use this type when counting bytes
-type ByteCount = int
+type ByteCount = int64
 
 func kib(c ByteCount) ByteCount {
 	c *= ByteCount(1024)

--- a/connect/go.mod
+++ b/connect/go.mod
@@ -11,6 +11,9 @@ require (
 	google.golang.org/protobuf v1.31.0
 )
 
-require github.com/go-playground/assert/v2 v2.2.0 // indirect
+require (
+	github.com/go-playground/assert/v2 v2.2.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
+)
 
 replace bringyour.com/protocol v0.0.0 => ../protocol/build/bringyour.com/protocol

--- a/connect/go.sum
+++ b/connect/go.sum
@@ -1,5 +1,7 @@
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -2033,6 +2033,22 @@ type Ip4Path struct {
     DestinationPort int
 }
 
+func (self *Ip4Path) Source() Ip4Path {
+    return Ip4Path{
+        Protocol: self.Protocol,
+        SourceIp: self.SourceIp,
+        SourcePort: self.SourcePort,
+    }
+}
+
+func (self *Ip4Path) Destination() Ip4Path {
+    return Ip4Path{
+        Protocol: self.Protocol,
+        DestinationIp: self.DestinationIp,
+        DestinationPort: self.DestinationPort,
+    }
+}
+
 
 // comparable
 type Ip6Path struct {
@@ -2041,6 +2057,22 @@ type Ip6Path struct {
     SourcePort int
     DestinationIp [16]byte
     DestinationPort int
+}
+
+func (self *Ip6Path) Source() Ip6Path {
+    return Ip6Path{
+        Protocol: self.Protocol,
+        SourceIp: self.SourceIp,
+        SourcePort: self.SourcePort,
+    }
+}
+
+func (self *Ip6Path) Destination() Ip6Path {
+    return Ip6Path{
+        Protocol: self.Protocol,
+        DestinationIp: self.DestinationIp,
+        DestinationPort: self.DestinationPort,
+    }
 }
 
 

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -1113,12 +1113,14 @@ func (self *TcpSequence) Run() {
         self.DestinationAuthority(),
         self.tcpBufferSettings.ConnectTimeout,
     )
-    // default is nodelay=true
     if err != nil {
         self.log("[init]connect error (%s)", err)
         return
     }
     defer socket.Close()
+
+    tcpSocket := socket.(*net.TCPConn)
+    tcpSocket.SetNoDelay(false)
 
     self.log("[init]connect success")
 

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -1705,6 +1705,7 @@ func (self *RemoteUserNatProvider) Close() {
 }
 
 
+// this is a basic implementation. See `RemoteUserNatWindowedClient` for a more robust implementation
 type RemoteUserNatClient struct {
     client *Client
     receivePacketCallback ReceivePacketFunction
@@ -1796,7 +1797,7 @@ func (self *RemoteUserNatClient) ClientReceive(sourceId Id, frames []*protocol.F
     source := Path{ClientId: sourceId}
 
     // only process frames from the destinations
-    if allow, ok := self.sourceFilter[source]; !ok || !allow {
+    if allow := self.sourceFilter[source]; !allow {
         ipLog("PACKET FILTERED")
         return
     }

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -25,7 +25,7 @@ import (
 // The UNAT emulates a raw socket using user-space sockets.
 
 
-const SendTimeout = 30 * time.Second
+const SendTimeout = 5 * time.Second
 
 
 var ipLog = LogFn(LogLevelDebug, "ip")

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -61,7 +61,7 @@ func DefaultTcpBufferSettings() *TcpBufferSettings {
         Mtu: DefaultMtu,
         // avoid fragmentation
         ReadBufferSize: DefaultMtu - max(Ipv4HeaderSizeWithoutExtensions, Ipv6HeaderSize) - max(UdpHeaderSize, TcpHeaderSizeWithoutExtensions),
-        WindowSize: mib(1),
+        WindowSize: int(mib(1)),
     }
     return tcpBufferSettings
 }
@@ -313,8 +313,8 @@ type UdpBufferSettings struct {
     ReadTimeout time.Duration
     WriteTimeout time.Duration
     IdleTimeout time.Duration
-    Mtu ByteCount
-    ReadBufferSize ByteCount
+    Mtu int
+    ReadBufferSize int
     ChannelBufferSize int
 }
 
@@ -788,13 +788,13 @@ type TcpBufferSettings struct {
     // ReadPollTimeout time.Duration
     // WritePollTimeout time.Duration
     IdleTimeout time.Duration
-    ReadBufferSize ByteCount
+    ReadBufferSize int
     ChannelBufferSize int
-    Mtu ByteCount
+    Mtu int
     // the window size is the max amount of packet data in memory for each sequence
     // TODO currently we do not enable window scale
     // TODO this value is max 2^16
-    WindowSize ByteCount
+    WindowSize int
 }
 
 

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -36,6 +36,22 @@ const TcpHeaderSizeWithoutExtensions = 20
 const debugVerifyHeaders = false
 
 
+// send from a raw socket
+// note `ipProtocol` is not supplied. The implementation must do a packet inspection to determine protocol
+type SendPacketFunction func(source Path, provideMode protocol.ProvideMode, packet []byte, timeout time.Duration) bool
+
+
+// receive into a raw socket
+type ReceivePacketFunction func(source Path, ipProtocol IpProtocol, packet []byte)
+
+
+type UserNatClient interface {
+    // `SendPacketFunction`
+    SendPacket(source Path, provideMode protocol.ProvideMode, packet []byte, timeout time.Duration) bool
+    Close()
+}
+
+
 func DefaultUdpBufferSettings() *UdpBufferSettings {
     return &UdpBufferSettings{
         ReadTimeout: 120 * time.Second,
@@ -61,22 +77,6 @@ func DefaultTcpBufferSettings() *TcpBufferSettings {
         WindowSize: int(mib(1)),
     }
     return tcpBufferSettings
-}
-
-
-// send from a raw socket
-// note `ipProtocol` is not supplied. The implementation must do a packet inspection to determine protocol
-type SendPacketFunction func(source Path, provideMode protocol.ProvideMode, packet []byte, timeout time.Duration) bool
-
-
-// receive into a raw socket
-type ReceivePacketFunction func(source Path, ipProtocol IpProtocol, packet []byte)
-
-
-type UserNatClient interface {
-    // `SendPacketFunction`
-    SendPacket(source Path, provideMode protocol.ProvideMode, packet []byte, timeout time.Duration) bool
-    Close()
 }
 
 

--- a/connect/ip_remote_multi_client.go
+++ b/connect/ip_remote_multi_client.go
@@ -1,18 +1,17 @@
 package connect
 
 import (
-	"context"
-	"time"
-	"sync"
-	"reflect"
-	"errors"
-	"fmt"
+    "context"
+    "time"
+    "sync"
+    "reflect"
+    "errors"
+    "fmt"
 
-	"golang.org/x/exp/maps"
+    "golang.org/x/exp/maps"
 
-	"bringyour.com/protocol"
+    "bringyour.com/protocol"
 )
-
 
 
 // multi client is a sender approach to mitigate bad destinations
@@ -25,173 +24,321 @@ import (
 // net frame count statistics (acks - nacks)
 
 
-
-
-/*
-Score is Acked - unacked
-Max unpacked per sender
-If no available senders, wait for timeout, then expand
-*/
-
-type ProviderSpec struct {
-	// FIXME
+type MultiClientTesting interface {
+    NextDesintationIds(count int, excludedClientIds []Id) map[Id]ByteCount
+    NewClientArgs() (Id, *ClientAuth)
+    SetTransports(client *Client)
 }
-
-
 
 
 type parsedPacket struct {
-	packet []byte
-	ipPath *ipPath
+    packet []byte
+    ipPath *IpPath
 }
 
 func newParsedPacket(packet []byte) (*parsedPacket, error) {
-	// FIXME
-	return nil, nil
+    ipPath, err := ParseIpPath(packet)
+    if err != nil {
+        return nil, err
+    }
+    return &parsedPacket{
+        packet: packet,
+        ipPath: ipPath,
+    }, nil
+}
+
+
+func DefaultMultiClientSettings() *MultiClientSettings {
+    return &MultiClientSettings{
+        WindowSizeMin: 4,
+        // reconnects per source
+        WindowSizeReconnectScale: 1.0,
+        MultiWriteTimeoutExpandSize: 2,
+        ClientNackInitialLimit: 1,
+        ClientNackMaxLimit: 8 * 1024,
+        // linear addition on each ack
+        ClientNackScale: 100,
+        WriteTimeout: 5 * time.Second,
+        MultiWriteTimeout: 1 * time.Second,
+        WindowExpandTimeout: 1 * time.Second,
+        WindowEnumerateEmptyTimeout: 1 * time.Second,
+        WindowEnumerateErrorTimeout: 1 * time.Second,
+        StatsWindowDuration: 300 * time.Second,
+    }
 }
 
 
 type MultiClientSettings struct {
+    WindowSizeMin int
+    WindowSizeReconnectScale float32
+    MultiWriteTimeoutExpandSize int
 
-	WindowSizeMin int
-	WindowSizeReconnectScale float32
+    ClientNackInitialLimit int
+    ClientNackMaxLimit int
+    ClientNackScale float32
+    ClientWriteTimeout time.Duration
 
-	ClientNackInitialLimit int
-	ClientNackMaxLimit int
-	ClientNackScale float32
+    WriteTimeout time.Duration
+    MultiWriteTimeout time.Duration
+    WindowExpandTimeout time.Duration
+    WindowEnumerateEmptyTimeout time.Duration
+    WindowEnumerateErrorTimeout time.Duration
 
-	WriteTimeout time.Duration
-	MultiWriteTimeout time.Duration
-	WindowExpandTimeout time.Duration
-
+    StatsWindowDuration time.Duration
 }
 
 
 type RemoteUserNatMultiClient struct {
-	ctx context.Context
-	cancel context.CancelFunc
-	specs []*ProviderSpec
+    ctx context.Context
+    cancel context.CancelFunc
 
-	settings *MultiClientSettings
+    api *BringYourApi
+    platformUrl string
 
-
+    specs []*ProviderSpec
 
     receivePacketCallback ReceivePacketFunction
 
+    settings *MultiClientSettings
+    testing MultiClientTesting
 
     window *multiClientWindow
 
+    stateLock sync.Mutex
+    ip4PathClients map[Ip4Path]*multiClientChannel 
+    ip6PathClients map[Ip6Path]*multiClientChannel
+    clientIp4Paths map[*multiClientChannel]map[Ip4Path]bool
+    clientIp6Paths map[*multiClientChannel]map[Ip6Path]bool
+}
 
-	ip4PathClients map[ip4Path]*multiClientChannel 
-	ip6PathClients map[ip6Path]*multiClientChannel
-	clientIp4Paths map[*multiClientChannel]map[ip4Path]bool
-	clientIp6Paths map[*multiClientChannel]map[ip6Path]bool
+func NewRemoteUserNatMultiClientWithDefaults(
+    ctx context.Context,
+    apiUrl string,
+    byJwt string,
+    platformUrl string,
+    specs []*ProviderSpec,
+    receivePacketCallback ReceivePacketFunction,
+) *RemoteUserNatMultiClient {
+    return NewRemoteUserNatMultiClient(
+        ctx,
+        apiUrl,
+        byJwt,
+        platformUrl,
+        specs,
+        receivePacketCallback,
+        DefaultMultiClientSettings(),
+    )
 }
 
 func NewRemoteUserNatMultiClient(
-	ctx context.Context,
-	specs []*ProviderSpec,
-	settings *MultiClientSettings,
+    ctx context.Context,
+    apiUrl string,
+    byJwt string,
+    platformUrl string,
+    specs []*ProviderSpec,
+    receivePacketCallback ReceivePacketFunction,
+    settings *MultiClientSettings,
 ) *RemoteUserNatMultiClient {
-	cancelCtx, cancel := context.WithCancel(ctx)
-
-	return &RemoteUserNatMultiClient{
-		ctx: cancelCtx,
-		cancel: cancel,
-		specs: specs,
-		settings: settings,
-	}
+    return NewRemoteUserNatMultiClientWithTesting(
+        ctx,
+        apiUrl,
+        byJwt,
+        platformUrl,
+        specs,
+        receivePacketCallback,
+        settings,
+        nil,
+    )
 }
 
-// func NewRemoteUserNatMultiClientFromDescription(description string) {
+func NewRemoteUserNatMultiClientWithTesting(
+    ctx context.Context,
+    apiUrl string,
+    byJwt string,
+    platformUrl string,
+    specs []*ProviderSpec,
+    receivePacketCallback ReceivePacketFunction,
+    settings *MultiClientSettings,
+    testing MultiClientTesting,
+) *RemoteUserNatMultiClient {
+    cancelCtx, cancel := context.WithCancel(ctx)
 
-// }
+    api := NewBringYourApi(apiUrl)
+    api.SetByJwt(byJwt)
 
+    window := newMultiClientWindow(
+        cancelCtx,
+        cancel,
+        api,
+        platformUrl,
+        specs,
+        receivePacketCallback,
+        settings,
+        testing,
+    )
 
-func (self *RemoteUserNatMultiClient) getPathClient(ipPath *ipPath) *multiClientChannel {
-	// FIXME
-	return nil
+    return &RemoteUserNatMultiClient{
+        ctx: cancelCtx,
+        cancel: cancel,
+        api: api,
+        platformUrl: platformUrl,
+        specs: specs,
+        receivePacketCallback: receivePacketCallback,
+        settings: settings,
+        testing: testing,
+        window: window,
+        ip4PathClients: map[Ip4Path]*multiClientChannel{},
+        ip6PathClients: map[Ip6Path]*multiClientChannel{},
+        clientIp4Paths: map[*multiClientChannel]map[Ip4Path]bool{},
+        clientIp6Paths: map[*multiClientChannel]map[Ip6Path]bool{},
+    }
 }
 
-func (self *RemoteUserNatMultiClient) setPathClient(ipPath *ipPath, client *multiClientChannel) {
-	// FIXME
+func (self *RemoteUserNatMultiClient) getPathClient(ipPath *IpPath) *multiClientChannel {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    switch ipPath.Version {
+    case 4:
+        ip4Path := ipPath.ToIp4Path()
+        return self.ip4PathClients[ip4Path]
+    case 6:
+        ip6Path := ipPath.ToIp6Path()
+        return self.ip6PathClients[ip6Path]
+    default:
+        panic(fmt.Errorf("Bad protocol version %d", ipPath.Version))
+    }
 }
 
-func (self *RemoteUserNatMultiClient) removePathClient(ipPath *ipPath, client *multiClientChannel) {
-	// FIXME
+func (self *RemoteUserNatMultiClient) setPathClient(ipPath *IpPath, client *multiClientChannel) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+    
+    switch ipPath.Version {
+    case 4:
+        ip4Path := ipPath.ToIp4Path()
+        self.ip4PathClients[ip4Path] = client
+        ip4Paths, ok := self.clientIp4Paths[client]
+        if !ok {
+            ip4Paths = map[Ip4Path]bool{}
+            self.clientIp4Paths[client] = ip4Paths
+        }
+        ip4Paths[ip4Path] = true
+    case 6:
+        ip6Path := ipPath.ToIp6Path()
+        self.ip6PathClients[ip6Path] = client
+        ip6Paths, ok := self.clientIp6Paths[client]
+        if !ok {
+            ip6Paths = map[Ip6Path]bool{}
+            self.clientIp6Paths[client] = ip6Paths
+        }
+        ip6Paths[ip6Path] = true
+    default:
+        panic(fmt.Errorf("Bad protocol version %d", ipPath.Version))
+    }
+}
+
+func (self *RemoteUserNatMultiClient) removePathClient(ipPath *IpPath, client *multiClientChannel) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+    
+    switch ipPath.Version {
+    case 4:
+        ip4Path := ipPath.ToIp4Path()
+        delete(self.ip4PathClients, ip4Path)
+        if ip4Paths, ok := self.clientIp4Paths[client]; ok {
+            delete(ip4Paths, ip4Path)
+            if len(ip4Paths) == 0 {
+                delete(self.clientIp4Paths, client)
+            }
+        }
+    case 6:
+        ip6Path := ipPath.ToIp6Path()
+        delete(self.ip6PathClients, ip6Path)
+        if ip6Paths, ok := self.clientIp6Paths[client]; ok {
+            delete(ip6Paths, ip6Path)
+            if len(ip6Paths) == 0 {
+                delete(self.clientIp6Paths, client)
+            }
+        }
+    default:
+        panic(fmt.Errorf("Bad protocol version %d", ipPath.Version))
+    }
 }
 
 func (self *RemoteUserNatMultiClient) removeClient(client *multiClientChannel) {
-	// FIXME
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+    
+    if ip4Paths, ok := self.clientIp4Paths[client]; ok {
+        delete(self.clientIp4Paths, client)
+        for ip4Path, _ := range ip4Paths {
+            delete(self.ip4PathClients, ip4Path)
+        }
+    }
+
+    if ip6Paths, ok := self.clientIp6Paths[client]; ok {
+        delete(self.clientIp6Paths, client)
+        for ip6Path, _ := range ip6Paths {
+            delete(self.ip6PathClients, ip6Path)
+        }
+    }
+
+    // client.Close()
 }
 
 
+func (self *RemoteUserNatMultiClient) SendPacket(source Path, provideMode protocol.ProvideMode, packet []byte) {
+    HandleError(func() {
+        self._SendPacket(source, provideMode, packet)
+    })
+}
 
 // `SendPacketFunction`
-func (self *RemoteUserNatMultiClient) SendPacket(source Path, provideMode protocol.ProvideMode, packet []byte) {
+func (self *RemoteUserNatMultiClient) _SendPacket(source Path, provideMode protocol.ProvideMode, packet []byte) {
+    parsedPacket, err := newParsedPacket(packet)
+    if err != nil {
+        // bad packet
+        return
+    }
 
-	// not source and provide mode are about the logical origin of the packet
-	// can ignore them after security checks
+    if client := self.getPathClient(parsedPacket.ipPath); client != nil {
+        select {
+        case <- self.ctx.Done():
+            return
+        // the client was already selected so do not limit sending by the nack limit
+        // at this point the limit is the send buffer
+        case client.SendNoLimit() <- parsedPacket:
+            return
+        case <- time.After(self.settings.WriteTimeout):
+            fmt.Printf("[multi] Existing path timeout %s->%s\n", client.args.clientId, client.args.destinationId)
 
-	// frame
+            // now we can change the routing of this path
+            self.removePathClient(parsedPacket.ipPath, client)
+        }
+    }
 
-	// if transfer path is already assigned to a client, and the client is still in the window, use it
+    for {
+        orderedClients, removedClients := self.window.OrderedClients(self.settings.WindowExpandTimeout)
+        fmt.Printf("[multi] Window =%d -%d\n", len(orderedClients), len(removedClients))
 
-	// expand window size to match target size
+        for _, client := range removedClients {
+            fmt.Printf("[multi] Remove client %s->%s.\n", client.args.clientId, client.args.destinationId)
+            
+            self.removeClient(client)
+        }
 
-	// order senders by acked - nacked in window (window send count)
-	// in order, try non blocking write
+        for _, client := range orderedClients {
+            select {
+            case client.Send() <- parsedPacket:
+                fmt.Printf("[multi] Set client %s->%s.\n", client.args.clientId, client.args.destinationId)
 
-	// use multi select write
-	// on multiwritetimeout, add new client
-
-
-	// the max nack count of the client expands with each successful ack
-	// max nack starts at 1
-	// a failed ack closes the client immediately
-
-
-	// expand window to match target size
-
-
-
-
-
-
-
-	parsedPacket, err := newParsedPacket(packet)
-	if err != nil {
-		// bad packet
-		return
-	}
-
-	if client := self.getPathClient(parsedPacket.ipPath); client != nil {
-		select {
-		case <- self.ctx.Done():
-			return
-		case client.Send() <- parsedPacket:
-			return
-		case <- time.After(WriteTimeout):
-			// now we can change the routing of this path
-			self.removePathClient(parsedPacket.ipPath, client)
-		}
-	}
-
-	for {
-		orderedClients, removedClients := self.window.OrderedClients(ExpandTimeout)
-		for _, client := range removedClients {
-			self.removeClient(client)
-		}
-
-		for _, client := range orderedClients {
-			select {
-			case client.Send() <- parsedPacket:
-				// lock the path to the client
-            	self.setPathClient(parsedPacket.ipPath, client)
-				return
-			default:
-			}
-		}
+                // lock the path to the client
+                self.setPathClient(parsedPacket.ipPath, client)
+                return
+            default:
+            }
+        }
 
         // select cases are in order:
         // - self.ctx.Done
@@ -224,7 +371,7 @@ func (self *RemoteUserNatMultiClient) SendPacket(source Path, provideMode protoc
         timeoutIndex := len(selectCases)
         selectCases = append(selectCases, reflect.SelectCase{
             Dir: reflect.SelectRecv,
-            Chan: reflect.ValueOf(time.After(MultiWriteTimeout)),
+            Chan: reflect.ValueOf(time.After(self.settings.MultiWriteTimeout)),
         })
 
         chosenIndex, _, _ := reflect.Select(selectCases)
@@ -234,24 +381,770 @@ func (self *RemoteUserNatMultiClient) SendPacket(source Path, provideMode protoc
             // return errors.New("Done")
             return
         case timeoutIndex:
+            fmt.Printf("[multi] Timeout expand\n")
+
             // return errors.New("Timeout")
+            self.window.ExpandBy(self.settings.MultiWriteTimeoutExpandSize)
             return
         default:
             // a route
             clientIndex := chosenIndex - clientStartIndex
             client := orderedClients[clientIndex]
+
+            fmt.Printf("[multi] Set client after select %s->%s.\n", client.args.clientId, client.args.destinationId)
+
             // lock the path to the client
             self.setPathClient(parsedPacket.ipPath, client)
-			return
+            return
         }
-	}
+    }
 }
 
 // `connect.ReceiveFunction`
-func (self *RemoteUserNatMultiClient) ClientReceive(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
-	// the client channels have already filtered the messages for the actual destinations only
+// func (self *RemoteUserNatMultiClient) ClientReceive(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
+//     // the client channels have already filtered the messages for the actual destinations only
 
-	source := Path{ClientId: sourceId}
+//     source := Path{ClientId: sourceId}
+
+//     for _, frame := range frames {
+//         switch frame.MessageType {
+//         case protocol.MessageType_IpIpPacketFromProvider:
+//             ipPacketFromProvider_, err := FromFrame(frame)
+//             if err != nil {
+//                 panic(err)
+//             }
+//             ipPacketFromProvider := ipPacketFromProvider_.(*protocol.IpPacketFromProvider)
+
+//             fmt.Printf("remote user nat client r packet %s<-\n", source)
+
+//             self.receivePacketCallback(source, IpProtocolUnknown, ipPacketFromProvider.IpPacket.PacketBytes)
+//         }
+//     }
+// }
+
+func (self *RemoteUserNatMultiClient) Close() {
+    self.cancel()
+}
+
+
+type multiClientWindow struct {
+    ctx context.Context
+    cancel context.CancelFunc
+
+    api *BringYourApi
+    platformUrl string
+
+    specs []*ProviderSpec
+    receivePacketCallback ReceivePacketFunction
+
+    settings *MultiClientSettings
+    testing MultiClientTesting
+
+    clientChannelArgs chan *multiClientChannelArgs
+
+    stateLock sync.Mutex
+    destinationClients map[Id]*multiClientChannel
+
+    windowUpdate *Monitor
+}
+
+func newMultiClientWindow(
+    ctx context.Context,
+    cancel context.CancelFunc,
+    api *BringYourApi,
+    platformUrl string,
+    specs []*ProviderSpec,
+    receivePacketCallback ReceivePacketFunction,
+    settings *MultiClientSettings,
+    testing MultiClientTesting,
+) *multiClientWindow {
+    window := &multiClientWindow{
+        ctx: ctx,
+        cancel: cancel,
+        api: api,
+        platformUrl: platformUrl,
+        specs: specs,
+        receivePacketCallback: receivePacketCallback,
+        settings: settings,
+        testing: testing,
+        clientChannelArgs: make(chan *multiClientChannelArgs),
+        destinationClients: map[Id]*multiClientChannel{},
+        windowUpdate: NewMonitor(),
+    }
+
+    go HandleError(window.randomEnumerateClientArgs, cancel)
+
+    return window
+}
+
+func (self *multiClientWindow) randomEnumerateClientArgs() {
+    // continually reset the visited set when there are no more
+    visitedDestinationIds := map[Id]bool{}
+    for {
+
+        destinationIds := []Id{}
+        for {
+            next := func(count int) (map[Id]ByteCount, error) {
+                if self.testing != nil {
+                    clientIdEstimatedBytesPerSecond := self.testing.NextDesintationIds(
+                        count,
+                        maps.Keys(visitedDestinationIds),
+                    )
+                    return clientIdEstimatedBytesPerSecond, nil
+                } else {
+                    findProviders2 := &FindProviders2Args{
+                        Specs: self.specs,
+                        ExcludeClientIds: maps.Keys(visitedDestinationIds),
+                        Count: count,
+                    }
+
+                    result, err := self.api.FindProviders2Sync(findProviders2)
+                    if err != nil {
+                        return nil, err
+                    }
+
+                    clientIdEstimatedBytesPerSecond := map[Id]ByteCount{}
+                    for _, provider := range result.Providers {
+                        clientIdEstimatedBytesPerSecond[provider.ClientId] = provider.EstimatedBytesPerSecond
+                    }
+
+                    return clientIdEstimatedBytesPerSecond, nil
+                }
+            }
+
+            nextDestinationIds, err := next(1)
+            fmt.Printf("[multi] Window enumerate found %v (%v).\n", nextDestinationIds, err)
+            if err != nil {
+                select {
+                case <- self.ctx.Done():
+                    return
+                case <- time.After(self.settings.WindowEnumerateErrorTimeout):
+                    fmt.Printf("[multi] Window enumerate error timeout.\n")
+                }
+            } else if 0 < len(nextDestinationIds) {
+                for destinationId, _ := range nextDestinationIds {
+                    destinationIds = append(destinationIds, destinationId)
+                    visitedDestinationIds[destinationId] = true
+                }
+                break
+            } else {
+                // reset
+                visitedDestinationIds = map[Id]bool{}
+                select {
+                case <- self.ctx.Done():
+                    return
+                case <- time.After(self.settings.WindowEnumerateEmptyTimeout):
+                    fmt.Printf("[multi] Window enumerate empty timeout.\n")
+                }
+            }
+        }
+
+        fmt.Printf("[multi] Window next destinations %d\n", len(destinationIds))
+        
+        for _, destinationId := range destinationIds {
+            if self.testing != nil {
+                clientId, clientAuth := self.testing.NewClientArgs()
+                args := &multiClientChannelArgs{
+                    platformUrl: self.platformUrl,
+                    destinationId: destinationId,
+                    clientId: clientId,
+                    clientAuth: clientAuth,
+                }
+                select {
+                case <- self.ctx.Done():
+                    return
+                case self.clientChannelArgs <- args:
+                }
+            } else {
+                auth := func() (string, error) {
+                    // note the derived client id will be inferred by the api jwt
+                    authNetworkClient := &AuthNetworkClientArgs{
+                        Description: "multi client",
+                        DeviceSpec: "multi client",
+                    }
+
+                    result, err := self.api.AuthNetworkClientSync(authNetworkClient)
+                    if err != nil {
+                        return "", err
+                    }
+
+                    if result.Error != nil {
+                        return "", errors.New(result.Error.Message)
+                    }
+
+                    return result.ByClientJwt, nil
+                }
+
+                if byJwtStr, err := auth(); err == nil {
+                    byJwt, err := ParseByJwtUnverified(byJwtStr)
+                    if err != nil {
+                        // in this case we cannot clean up the client because we don't know the client id
+                        panic(err)
+                    }
+
+                    clientAuth := &ClientAuth{
+                        ByJwt: byJwtStr,
+                        InstanceId: NewId(),
+                        AppVersion: "0.0.0-multi",
+                    }
+                    args := &multiClientChannelArgs{
+                        platformUrl: self.platformUrl,
+                        destinationId: destinationId,
+                        clientId: byJwt.ClientId,
+                        clientAuth: clientAuth,
+                    }
+
+                    select {
+                    case <- self.ctx.Done():
+                        removeClientAuth(args.clientId, self.api)
+                        return
+                    case self.clientChannelArgs <- args:
+                    }
+                } else {
+                    fmt.Printf("[multi] Could not auth client.\n")
+                }
+            }
+        }
+    }
+}
+
+func (self *multiClientWindow) ExpandBy(expandStep int) {
+    self.stateLock.Lock()
+    windowSize := len(self.destinationClients)
+    self.stateLock.Unlock()
+
+    self.expandTo(windowSize + expandStep)
+}
+
+func (self *multiClientWindow) expandTo(targetWindowSize int) {
+    endTime := time.Now().Add(self.settings.WindowExpandTimeout)
+    for {
+        update := self.windowUpdate.NotifyChannel()
+        self.stateLock.Lock()
+        windowSize := len(self.destinationClients)
+        self.stateLock.Unlock()
+
+        fmt.Printf("[multi] Expand %d->%d\n", windowSize, targetWindowSize)
+
+        if targetWindowSize <= windowSize {
+            fmt.Printf("[multi] Expand done\n")
+            return
+        }
+
+        timeout := endTime.Sub(time.Now())
+        if timeout < 0 {
+            fmt.Printf("[multi] Expand window timeout\n")
+            return
+        }
+
+        select {
+        case <- self.ctx.Done():
+            return
+        case <- update:
+            // continue
+        case args := <- self.clientChannelArgs:
+            fmt.Printf("[multi] Expand got args %v\n", args)
+
+            self.stateLock.Lock()
+            _, ok := self.destinationClients[args.destinationId]
+            self.stateLock.Unlock()
+
+            if ok {
+                // already have a client in the window for this destination
+                removeClientAuth(args.clientId, self.api)
+            } else if client, err := newMultiClientChannel(
+                    self.ctx,
+                    args,
+                    self.api,
+                    self.receivePacketCallback,
+                    self.settings,
+                    self.testing,
+            ); err == nil {
+                go HandleError(func() {
+                    defer removeClientAuth(args.clientId, self.api)
+                    client.Run()
+                }, self.cancel)
+
+                self.stateLock.Lock()
+                self.destinationClients[args.destinationId] = client
+                self.stateLock.Unlock()
+                
+                self.windowUpdate.NotifyAll()
+            } else {
+                removeClientAuth(args.clientId, self.api)
+            }
+        case <- time.After(timeout):
+            fmt.Printf("[multi] Expand window timeout waiting for args\n")
+            return
+        }
+    }
+}
+
+func (self *multiClientWindow) OrderedClients(timeout time.Duration) ([]*multiClientChannel, []*multiClientChannel) {
+    self.stateLock.Lock()
+    clients := maps.Values(self.destinationClients)
+    self.stateLock.Unlock()
+
+    removedClients := []*multiClientChannel{}
+
+    netSourceCount := 0
+    clientWeights := map[*multiClientChannel]float32{}
+    for _, client := range clients {
+        stats, err := client.WindowStats()
+        if err != nil {
+            removedClients = append(removedClients, client)
+            self.stateLock.Lock()
+            delete(self.destinationClients, client.DestinationId())
+            self.stateLock.Unlock()
+            self.windowUpdate.NotifyAll()
+        } else {
+            netSourceCount += stats.sourceCount
+            clientWeights[client] = float32(stats.ackByteCount - stats.nackByteCount)
+        }
+    }
+
+    targetWindowSize := int(
+        float32(self.settings.WindowSizeMin) + 
+        float32(netSourceCount) * self.settings.WindowSizeReconnectScale,
+    )
+    if len(clients) - len(removedClients) < targetWindowSize {
+        self.expandTo(targetWindowSize)
+
+        self.stateLock.Lock()
+        clients = maps.Values(self.destinationClients)
+        self.stateLock.Unlock()
+    }
+
+    // now order the clients based on the stats
+    WeightedShuffle(clients, clientWeights)
+
+    return clients, removedClients
+}
+
+
+type multiClientChannelArgs struct {
+    platformUrl string
+    destinationId Id
+    clientId Id
+    clientAuth *ClientAuth
+}
+
+func removeClientAuth(clientId Id, api *BringYourApi) {
+    removeNetworkClient := &RemoveNetworkClientArgs{
+        ClientId: clientId,
+    }
+
+    api.RemoveNetworkClient(removeNetworkClient, NewApiCallback(func(result *RemoveNetworkClientResult, err error) {
+    }))
+}
+
+
+type multiClientEventType int
+const (
+    multiClientEventTypeAck multiClientEventType = 1
+    multiClientEventTypeNack multiClientEventType = 2
+    multiClientEventTypeError multiClientEventType = 3
+    multiClientEventTypeSource multiClientEventType = 4
+)
+
+
+type multiClientEvent struct {
+    eventType multiClientEventType
+    // ack bool
+    ackByteCount ByteCount
+    err error
+    ipPath *IpPath
+    eventTime time.Time
+}
+
+
+type clientWindowStats struct {
+    sourceCount int
+    ackCount int
+    nackCount int
+    ackByteCount ByteCount
+    nackByteCount ByteCount
+}
+
+
+type multiClientChannel struct {
+    ctx context.Context
+    cancel context.CancelFunc
+
+    args *multiClientChannelArgs
+
+    api *BringYourApi
+
+    send chan *parsedPacket
+    sendNoLimit chan *parsedPacket
+
+    receivePacketCallback ReceivePacketFunction
+
+    settings *MultiClientSettings
+
+    sourceFilter map[Path]bool
+
+    client *Client
+
+    stateLock sync.Mutex
+    // FIXME need to minimize memory here, use buckets
+    // FIXME need to bucket the events
+    events []*multiClientEvent
+    // destination -> source -> count
+    ip4DestinationSourceCount map[Ip4Path]map[Ip4Path]int
+    ip6DestinationSourceCount map[Ip6Path]map[Ip6Path]int
+    packetStats *clientWindowStats
+    endErr error
+
+    maxNackCount int
+
+    eventUpdate *Monitor
+}
+
+func newMultiClientChannel(
+    ctx context.Context,
+    args *multiClientChannelArgs,
+    api *BringYourApi,
+    receivePacketCallback ReceivePacketFunction,
+    settings *MultiClientSettings,
+    testing MultiClientTesting,
+) (*multiClientChannel, error) {
+    cancelCtx, cancel := context.WithCancel(ctx)
+
+    byJwt, err := ParseByJwtUnverified(args.clientAuth.ByJwt)
+    if err != nil {
+        return nil, err
+    }
+
+    clientSettings := DefaultClientSettings()
+    clientSettings.SendBufferSettings.AckTimeout = settings.WriteTimeout
+    client := NewClient(cancelCtx, byJwt.ClientId, clientSettings)
+    if testing != nil {
+        testing.SetTransports(client)
+    } else {
+        fmt.Printf("[multi] new platform transport %s %v\n", args.platformUrl, args.clientAuth)
+        NewPlatformTransportWithDefaults(
+            cancelCtx,
+            args.platformUrl,
+            args.clientAuth,
+            client.RouteManager(),
+        )
+    }
+
+    sourceFilter := map[Path]bool{
+        Path{ClientId:args.destinationId}: true,
+    }
+
+    clientChannel := &multiClientChannel{
+        ctx: cancelCtx,
+        cancel: cancel,
+        args: args,
+        api: api,
+        send: make(chan *parsedPacket),
+        sendNoLimit: make(chan *parsedPacket),
+        receivePacketCallback: receivePacketCallback,
+        settings: settings,
+        sourceFilter: sourceFilter,
+        client: client,
+        events: []*multiClientEvent{},
+        ip4DestinationSourceCount: map[Ip4Path]map[Ip4Path]int{},
+        ip6DestinationSourceCount: map[Ip6Path]map[Ip6Path]int{},
+        packetStats: &clientWindowStats{},
+        endErr: nil,
+        maxNackCount: settings.ClientNackInitialLimit,
+        eventUpdate: NewMonitor(),
+    }
+
+    // go clientChannel.run()
+
+    client.AddReceiveCallback(clientChannel.clientReceive)
+
+    return clientChannel, nil
+}
+
+func (self *multiClientChannel) Run() {
+    defer func() {
+        self.cancel()
+        self.addError(errors.New("Done."))
+    }()
+
+    send := func(parsedPacket *parsedPacket) {
+        ipPacketToProvider := &protocol.IpPacketToProvider{
+            IpPacket: &protocol.IpPacket{
+                PacketBytes: parsedPacket.packet,
+            },
+        }
+        if frame, err := ToFrame(ipPacketToProvider); err != nil {
+            self.addError(err)
+        } else {
+            packetByteCount := ByteCount(len(parsedPacket.packet))
+            self.addNack(packetByteCount)
+            self.addSource(parsedPacket.ipPath)
+            ackCallback := func(err error) {
+                fmt.Printf("[multi] ack callback (%v)\n", err)
+                if err == nil {
+                    self.addAck(packetByteCount)
+                } else {
+                    self.addError(err)
+                }
+            }
+
+            fmt.Printf("[multi] Send ->%s\n", self.args.destinationId)
+
+            success := self.client.SendWithTimeout(
+                frame,
+                self.args.destinationId,
+                ackCallback,
+                self.settings.WriteTimeout,
+            )
+            if !success {
+                fmt.Printf("[multi] Timeout ->%s\n", self.args.destinationId)
+
+                self.addError(errors.New("Send timeout."))
+            }
+        }
+    }
+
+    for {
+        update := self.eventUpdate.NotifyChannel()
+        if self.isMaxAcks() {
+            select {
+            case <- self.ctx.Done():
+                return
+            case parsedPacket, ok := <- self.sendNoLimit:
+                if !ok {
+                    return
+                }
+                send(parsedPacket)
+            case <- update:
+            }
+        } else {
+            select {
+            case <- self.ctx.Done():
+                return
+            case parsedPacket, ok := <- self.sendNoLimit:
+                if !ok {
+                    return
+                }
+                send(parsedPacket)
+            case parsedPacket, ok := <- self.send:
+                if !ok {
+                    return
+                }
+                send(parsedPacket)
+            }
+        }
+    }
+}
+
+func (self *multiClientChannel) DestinationId() Id {
+    return self.args.destinationId
+}
+
+func (self *multiClientChannel) Send() chan *parsedPacket {
+    return self.send
+}
+
+func (self *multiClientChannel) SendNoLimit() chan *parsedPacket {
+    return self.sendNoLimit
+}
+
+func (self *multiClientChannel) isMaxAcks() bool {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    return (self.maxNackCount <= self.packetStats.nackCount)
+}
+
+func (self *multiClientChannel) addNack(ackByteCount ByteCount) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    self.packetStats.nackCount += 1
+    self.packetStats.nackByteCount += ackByteCount
+
+    self.events = append(self.events, &multiClientEvent{
+        eventType: multiClientEventTypeNack,
+        ackByteCount: ackByteCount,
+        eventTime: time.Now(),
+    })
+
+    self.eventUpdate.NotifyAll()
+}
+
+func (self *multiClientChannel) addAck(ackByteCount ByteCount) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    self.packetStats.nackCount -= 1
+    self.packetStats.nackByteCount -= ackByteCount
+    self.packetStats.ackCount += 1
+    self.packetStats.ackByteCount += ackByteCount
+
+    self.maxNackCount = min(
+        self.settings.ClientNackMaxLimit,
+        int(float32(self.maxNackCount) + self.settings.ClientNackScale),
+    )
+
+    self.events = append(self.events, &multiClientEvent{
+        eventType: multiClientEventTypeAck,
+        ackByteCount: ackByteCount,
+        eventTime: time.Now(),
+    })
+
+    self.eventUpdate.NotifyAll()
+}
+
+func (self *multiClientChannel) addSource(ipPath *IpPath) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    source := ipPath.Source()
+    destination := ipPath.Destination()
+    switch source.Version {
+    case 4:
+        sourceCount, ok := self.ip4DestinationSourceCount[destination.ToIp4Path()]
+        if !ok {
+            sourceCount = map[Ip4Path]int{}
+            self.ip4DestinationSourceCount[destination.ToIp4Path()] = sourceCount
+        }
+        sourceCount[source.ToIp4Path()] += 1
+    case 6:
+        sourceCount, ok := self.ip6DestinationSourceCount[destination.ToIp6Path()]
+        if !ok {
+            sourceCount = map[Ip6Path]int{}
+            self.ip6DestinationSourceCount[destination.ToIp6Path()] = sourceCount
+        }
+        sourceCount[source.ToIp6Path()] += 1
+    default:
+        panic(fmt.Errorf("Bad protocol version %d", source.Version))
+    }
+
+    self.events = append(self.events, &multiClientEvent{
+        eventType: multiClientEventTypeSource,
+        ipPath: ipPath,
+        eventTime: time.Now(),
+    })
+
+    self.eventUpdate.NotifyAll()
+}
+
+func (self *multiClientChannel) addError(err error) {
+    self.stateLock.Lock()
+    defer self.stateLock.Unlock()
+
+    if self.endErr == nil {
+        self.endErr = err
+    }
+
+    self.events = append(self.events, &multiClientEvent{
+        eventType: multiClientEventTypeError,
+        err: err,
+        eventTime: time.Now(),
+    })
+
+    self.eventUpdate.NotifyAll()
+}
+
+func (self *multiClientChannel) WindowStats() (stats *clientWindowStats, returnErr error) {
+    changed := false
+
+    func() {
+        self.stateLock.Lock()
+        defer self.stateLock.Unlock()
+        
+        windowStart := time.Now().Add(-self.settings.StatsWindowDuration)
+
+        // remove events before the window start
+        i := 0
+        for i < len(self.events) {
+            event := self.events[i]
+            // fmt.Printf("[multi] event advance %v %s\n", event, windowStart)
+            if windowStart.Before(event.eventTime) {
+                break
+            }
+            switch event.eventType {
+            // `multiClientEventTypeNack` only ack or error can remove nack
+
+            case multiClientEventTypeAck:
+                self.packetStats.ackCount -= 1
+                self.packetStats.ackByteCount -= event.ackByteCount
+                changed = true
+
+            case multiClientEventTypeSource:
+                source := event.ipPath.Source()
+                destination := event.ipPath.Destination()
+                switch source.Version {
+                case 4:
+                    sourceCount, ok := self.ip4DestinationSourceCount[destination.ToIp4Path()]
+                    if ok {
+                        count := sourceCount[source.ToIp4Path()]
+                        if count - 1 <= 0 {
+                            delete(sourceCount, source.ToIp4Path())
+                        } else {
+                            sourceCount[source.ToIp4Path()] = count - 1
+                        }
+                        if len(sourceCount) == 0 {
+                            delete(self.ip4DestinationSourceCount, destination.ToIp4Path())
+                        }
+                    }
+                case 6:
+                    sourceCount, ok := self.ip6DestinationSourceCount[destination.ToIp6Path()]
+                    if ok {
+                        count := sourceCount[source.ToIp6Path()]
+                        if count - 1 <= 0 {
+                            delete(sourceCount, source.ToIp6Path())
+                        } else {
+                            sourceCount[source.ToIp6Path()] = count - 1
+                        }
+                        if len(sourceCount) == 0 {
+                            delete(self.ip6DestinationSourceCount, destination.ToIp6Path())
+                        }
+                    }
+                default:
+                    panic(fmt.Errorf("Bad protocol version %d", source.Version))
+                }
+                changed = true
+
+            // `multiClientEventTypeError` nothing to remove, ended
+            }
+            self.events[i] = nil
+            i += 1
+        }
+        self.events = self.events[i:]
+
+        maxSourceCount := 0
+        for _, sourceCounts := range self.ip4DestinationSourceCount {
+            maxSourceCount = max(maxSourceCount, len(sourceCounts))
+        }
+        for _, sourceCounts := range self.ip6DestinationSourceCount {
+            maxSourceCount = max(maxSourceCount, len(sourceCounts))
+        }
+
+        stats = &clientWindowStats{
+            sourceCount: maxSourceCount,
+            ackCount: self.packetStats.ackCount,
+            nackCount: self.packetStats.nackCount,
+            ackByteCount: self.packetStats.ackByteCount,
+            nackByteCount: self.packetStats.nackByteCount,
+        }
+        returnErr = self.endErr
+    }()
+
+    if changed {
+        self.eventUpdate.NotifyAll()
+    }
+    return
+}
+
+// `connect.ReceiveFunction`
+func (self *multiClientChannel) clientReceive(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
+    source := Path{ClientId: sourceId}
+
+    // only process frames from the destinations
+    if allow := self.sourceFilter[source]; !allow {
+        return
+    }
 
     for _, frame := range frames {
         switch frame.MessageType {
@@ -262,474 +1155,18 @@ func (self *RemoteUserNatMultiClient) ClientReceive(sourceId Id, frames []*proto
             }
             ipPacketFromProvider := ipPacketFromProvider_.(*protocol.IpPacketFromProvider)
 
-            fmt.Printf("remote user nat client r packet %s<-\n", source)
-
+            fmt.Printf("[multi] Receive %s<-\n", self.args.destinationId)
+            
             self.receivePacketCallback(source, IpProtocolUnknown, ipPacketFromProvider.IpPacket.PacketBytes)
         }
     }
 }
 
+/*
+func (self *multiClientChannel) Close() {
+    self.cancel()
 
-
-
-// client send queue frame
-// don't read if max nack count <= nack count 
-// windowStats(dst), int and error
-
-
-
-
-type multiClientWindow struct {
-	ctx context.Context
-
-	specs []*ProviderSpec
-	receivePacketCallback ReceivePacketFunction
-
-	clientChannelArgs chan *multiClientChannelArgs
-
-	stateLock sync.Mutex
-	destinationClients map[Id]*multiClientChannel
-
-	windowUpdate *Monitor
+    close(self.send)
+    close(self.sendNoLimit)
 }
-
-func newMultiClientWindow(
-	ctx context.Context,
-	specs []*ProviderSpec,
-	receivePacketCallback ReceivePacketFunction,
-) *multiClientWindow {
-	window := &multiClientWindow{
-		ctx: ctx,
-		specs: specs,
-		receivePacketCallback: receivePacketCallback,
-		clientChannelArgs: make(chan *multiClientChannelArgs),
-		destinationClients: map[Id]*multiClientChannel{},
-	}
-
-	go window.randomEnumerateClientArgs()
-
-	return window
-}
-
-func (self *multiClientWindow) randomEnumerateClientArgs() {
-	// keep track of all client ids so far
-	// reset visited client ids if no new
-	visitedDestinationIds := map[Id]bool{}
-	for {
-
-		var destinationId Id
-		for {
-			nextDestinationIds := APINEXT(self.specs, maps.Keys(visitedDestinationIds), 1)
-			if 0 < len(nextDestinationIds) {
-				destinationId = nextDestinationIds[0]
-				visitedDestinationIds[destinationId] = true
-				break
-			}
-			// reset
-			visitedDestinationIds = map[Id]bool{}
-			select {
-			case <- self.ctx.Done():
-				return
-			case <- time.After(WindowEnumerateEmptyTimeout):
-			}
-		}
-
-		
-		// FIXME login client id
-		// FIXME are we parsing client id from the jwt locally?
-		// ParseByJwtUnverified
-		APILOGINCLIENT()
-
-		var clientId Id
-		clientAuth := &ClientAuth{}
-		args := &multiClientChannelArgs{
-			destinationId: destinationId,
-			clientId: clientId,
-			clientAuth: clientAuth,
-		} 
-
-		select {
-		case <- self.ctx.Done():
-			args.Close()
-			return
-		case self.clientChannelArgs <- args:
-		}
-	}
-}
-
-func (self *multiClientWindow) ExpandBy(expandStep int) {
-	self.stateLock.Lock()
-	windowSize := len(self.destinationClients)
-	self.stateLock.Unlock()
-
-	self.expandTo(windowSize + expandStep)
-}
-
-func (self *multiClientWindow) expandTo(targetWindowSize int) {
-	endTime := time.Now().Add(ExpandTimeout)
-	for {
-		update := self.windowUpdate.NotifyChannel()
-		self.stateLock.Lock()
-		windowSize := len(self.destinationClients)
-		self.stateLock.Unlock()
-
-		if targetWindowSize <= windowSize {
-			return
-		}
-
-		timeout := endTime.Sub(time.Now())
-		if timeout < 0 {
-			return
-		}
-
-		select {
-		case <- self.ctx.Done():
-			return
-		case <- update:
-			// continue
-		case args := <- self.clientChannelArgs:
-			self.stateLock.Lock()
-			client, ok := self.destinationClients[args.destinationId]
-			self.stateLock.Unlock()
-
-			if ok {
-				// already iterated this destination
-				args.Close()
-			} else {
-				client = newMultiClientChannel(self.ctx, args, self.receivePacketCallback)
-				self.stateLock.Lock()
-				self.destinationClients[args.destinationId] = client
-				self.stateLock.Unlock()
-				self.windowUpdate.NotifyAll()
-			}
-		case <- time.After(timeout):
-			return
-		}
-	}
-}
-
-func (self *multiClientWindow) OrderedClients(timeout time.Duration) ([]*multiClientChannel, []*multiClientChannel) {
-	self.stateLock.Lock()
-	clients := maps.Values(self.destinationClients)
-	self.stateLock.Unlock()
-
-	// expand
-	netSrcCount := 0
-	clientWeights := map[*multiClientChannel]float32{}
-	for _, client := range clients {
-		stats, err := client.windowStats()
-		if err != nil {
-			self.stateLock.Lock()
-			delete(self.destinationClients, client.destinationId)
-			self.stateLock.Unlock()
-			self.windowUpdate.NotifyAll()
-		} else {
-			netSrcCount += stats.srcCount
-			clientWeights[client] = float32(stats.netPacketCount)
-		}
-	}
-
-	targetWindowSize := minSize + netSrcCount * scale
-	expandTo(targetWindowSize)
-
-	// now order the clients based on the stats
-	WeightedShuffle(clients, clientWeight)
-
-	return clients
-}
-
-
-
-
-
-type multiClientChannelArgs struct {
-	destinationId Id
-	clientId Id
-	clientAuth *ClientAuth
-}
-
-func (self *multiClientChannelArgs) Close() {
-	// FIXME remove the client usind the api
-
-	APIREMOVECLIENT(self.clientId)
-}
-
-
-type multiClientEventType int
-const (
-	multiClientEventTypeAck multiClientEventType = 1
-	multiClientEventTypeNack multiClientEventType = 2
-	multiClientEventTypeError multiClientEventType = 3
-	multiClientEventTypeSrc multiClientEventType = 4
-)
-
-
-type multiClientEvent struct {
-	eventType multiClientEventType
-	ack bool
-	err error
-	ipPath *ipPath
-	eventTime time.Time
-}
-
-
-type clientWindowStats struct {
-	srcCount int
-	ackCount int
-	nackCount int
-	ackByteCount ByteCount
-	nackByteCount ByteCount
-}
-
-
-type multiClientChannel struct {
-	ctx context.Context
-	cancel context.CancelFunc
-
-	args *multiClientChannelArgs
-
-	send chan *parsedPacket
-
-	receivePacketCallback ReceivePacketFunction
-	sourceFilter map[Path]bool
-
-	client *Client
-
-	
-
-	stateLock sync.Mutex
-	events []*multiClientEvent
-	srcCount map[src]int
-	packetStats *clientWindowStats
-	endErr error
-
-	maxNackCount int
-
-	eventUpdate *Monitor
-}
-
-func newMultiClientChannel(
-	ctx context.Context,
-	args *multiClientChannelArgs,
-	receivePacketCallback ReceivePacketFunction,
-) *multiClientChannel {
-	cancelCtx, cancel := context.WithCancel(ctx)
-
-
-	client := NewClientWithDefaults(cancelCtx)
-
-	transport := NewPlatformaTransport(cancelCtx, args.clientAuth, client.RouteManager())
-
-
-
-	sourceFilter := map[Path]bool{
-		args.destinationId: true,
-	}
-
-    clientChannel := &multiClientChannel{
-    	ctx: cancelCtx,
-    	cancel: cancel,
-    	args: args,
-    	send: make(chan *parsedPacket),
-    	receivePacketCallback: receivePacketCallback,
-    	sourceFilter: sourceFilter,
-    	client: client,
-    	events: []*multiClientEvent{},
-		srcCount: map[src]int{},
-		packetStats: &clientWindowStats{},
-		endErr: nil,
-    }
-
-
-	go clientChannel.run()
-
-	client.AddReceiveCallback(clientChannel)
-
-	return client
-}
-
-
-func (self *multiClientChannel) run() {
-	defer func() {
-		self.cancel()
-		self.addError(errors.New("Done."))
-		self.args.Close()
-	}()
-
-	for {
-		update := self.eventUpdate.NotifyChannel()
-		if self.isMaxAcks() {
-			select {
-			case <- self.ctx.Done():
-				return
-			case <- update:
-			}
-		} else {
-			select {
-			case <- self.ctx.Done():
-				return
-			case parsedPacket := <- self.send:
-				self.addNack()
-				self.addSrc(parsedPacket.ipPath)
-				success := self.client.SendWithTimeout(frame, destinationId, func(error) {
-					if err == nil {
-						self.addAck()
-					} else {
-						self.addError(err)
-						return
-					}
-				})
-				if !success {
-					self.addError(errors.New("Send failed."))
-				}
-			}
-		}
-	}
-}
-
-
-func (self *multiClientChannel) Send() chan *parsedPacket {
-	return self.send
-}
-
-
-func (self *multiClientChannel) isMaxAcks() {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-
-	return (self.maxNackCount <= self.packetStats.nackCount)
-}
-
-
-func (self *multiClientChannel) addNack() {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-
-	self.events = append(self.events, &multiClientEvent{
-		eventType: multiClientEventTypeAck,
-		ack: false,
-	})
-}
-
-func (self *multiClientChannel) addAck() {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-
-	self.events = append(self.events, &multiClientEvent{
-		eventType: multiClientEventTypeAck,
-		ack: true,
-	})
-}
-
-func (self *multiClientChannel) addSrc(ipPath *ipPath) {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-
-	self.events = append(self.events, &multiClientEvent{
-		eventType: multiClientEventTypeSrc,
-		ipPath: ipPath,
-	})
-}
-
-func (self *multiClientChannel) addError(err error) {
-	self.stateLock.Lock()
-	defer self.stateLock.Unlock()
-
-	self.events = append(self.events, &multiClientEvent{
-		eventType: multiClientEventTypeError,
-		err: err,
-	})
-}
-
-
-
-
-func (self *multiClientChannel) windowStats() (*clientWindowStats, error) {
-	
-	changed := false
-	self.stateLock.Lock()
-	// forward the event window
-	i := 0
-	for i < len(self.events) {
-		event := self.events[i]
-		if now < event.eventTime {
-			break
-		}
-		switch event.eventType {
-		case Nack:
-			self.packetStats.nackCount += 1
-			changed = true
-
-		case Ack:
-			self.packetStats.nackCount -= 1
-			self.packetStats.ackCount += 1
-			self.maxNackCount = min(self.maxNackCount + NACKSCALE, MAXNACKCOUNT)
-			changed = true
-
-		case Src:
-			self.srcCount[ipPath.Src()] += 1
-			changed = true
-
-		case Error:
-			if self.endErr == nil {
-				self.endErr = err
-				changed = true
-			}
-		}
-		self.events[i] = nil
-	}
-	self.events = self.events[:i]
-
-	out := &clientWindowStats{
-		srcCount: len(self.srcCount),
-		ackCount: self.packetStats.ackCount,
-		nackCount: self.packetStats.nackCount,
-		ackByteCount: self.packetStats.ackByteCount,
-		nackByteCount: self.packetStats.nackByteCount,
-	}
-	outErr := self.endErr
-
-	self.stateLock.Unlock()
-
-	if changed {
-		self.eventUpdate.NotifyAll()
-	}
-
-	return out, outErr
-}
-
-
-func (self *multiClientChannel) ClientReceive(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
-	source := Path{ClientId: sourceId}
-
-    // only process frames from the destinations
-    if allow := self.sourceFilter[source]; !allow {
-        return
-    }
-
-    self.receivePacketCallback(sourceId, frames, provideMode)
-}
-
-
-
-
-
-func APINEXT(specs []*ProviderSpec, excludeClientIds []Id, count int) []Id {
-	// FIXME
-	return []Id{}
-}
-
-
-func APILOGINCLIENT() {
-	// FIXME
-}
-
-
-func APIREMOVECLIENT(clientId Id) {
-	// FIXME
-}
-
-
-
-
-
+*/

--- a/connect/ip_remote_multi_client.go
+++ b/connect/ip_remote_multi_client.go
@@ -1,0 +1,735 @@
+package connect
+
+import (
+	"context"
+	"time"
+	"sync"
+	"reflect"
+	"errors"
+	"fmt"
+
+	"golang.org/x/exp/maps"
+
+	"bringyour.com/protocol"
+)
+
+
+
+// multi client is a sender approach to mitigate bad destinations
+// it maintains a window of compatible clients chosen using specs
+// (e.g. from a desription of the intent of use)
+// - the clients are rate limited by the number of outstanding acks (nacks)
+// - the size of allowed outstanding nacks increases with each ack,
+// scaling up successful destinations to use the full transfer buffer
+// - the clients are chosen with probability weighted by their 
+// net frame count statistics (acks - nacks)
+
+
+
+
+/*
+Score is Acked - unacked
+Max unpacked per sender
+If no available senders, wait for timeout, then expand
+*/
+
+type ProviderSpec struct {
+	// FIXME
+}
+
+
+
+
+type parsedPacket struct {
+	packet []byte
+	ipPath *ipPath
+}
+
+func newParsedPacket(packet []byte) (*parsedPacket, error) {
+	// FIXME
+	return nil, nil
+}
+
+
+type MultiClientSettings struct {
+
+	WindowSizeMin int
+	WindowSizeReconnectScale float32
+
+	ClientNackInitialLimit int
+	ClientNackMaxLimit int
+	ClientNackScale float32
+
+	WriteTimeout time.Duration
+	MultiWriteTimeout time.Duration
+	WindowExpandTimeout time.Duration
+
+}
+
+
+type RemoteUserNatMultiClient struct {
+	ctx context.Context
+	cancel context.CancelFunc
+	specs []*ProviderSpec
+
+	settings *MultiClientSettings
+
+
+
+    receivePacketCallback ReceivePacketFunction
+
+
+    window *multiClientWindow
+
+
+	ip4PathClients map[ip4Path]*multiClientChannel 
+	ip6PathClients map[ip6Path]*multiClientChannel
+	clientIp4Paths map[*multiClientChannel]map[ip4Path]bool
+	clientIp6Paths map[*multiClientChannel]map[ip6Path]bool
+}
+
+func NewRemoteUserNatMultiClient(
+	ctx context.Context,
+	specs []*ProviderSpec,
+	settings *MultiClientSettings,
+) *RemoteUserNatMultiClient {
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+	return &RemoteUserNatMultiClient{
+		ctx: cancelCtx,
+		cancel: cancel,
+		specs: specs,
+		settings: settings,
+	}
+}
+
+// func NewRemoteUserNatMultiClientFromDescription(description string) {
+
+// }
+
+
+func (self *RemoteUserNatMultiClient) getPathClient(ipPath *ipPath) *multiClientChannel {
+	// FIXME
+	return nil
+}
+
+func (self *RemoteUserNatMultiClient) setPathClient(ipPath *ipPath, client *multiClientChannel) {
+	// FIXME
+}
+
+func (self *RemoteUserNatMultiClient) removePathClient(ipPath *ipPath, client *multiClientChannel) {
+	// FIXME
+}
+
+func (self *RemoteUserNatMultiClient) removeClient(client *multiClientChannel) {
+	// FIXME
+}
+
+
+
+// `SendPacketFunction`
+func (self *RemoteUserNatMultiClient) SendPacket(source Path, provideMode protocol.ProvideMode, packet []byte) {
+
+	// not source and provide mode are about the logical origin of the packet
+	// can ignore them after security checks
+
+	// frame
+
+	// if transfer path is already assigned to a client, and the client is still in the window, use it
+
+	// expand window size to match target size
+
+	// order senders by acked - nacked in window (window send count)
+	// in order, try non blocking write
+
+	// use multi select write
+	// on multiwritetimeout, add new client
+
+
+	// the max nack count of the client expands with each successful ack
+	// max nack starts at 1
+	// a failed ack closes the client immediately
+
+
+	// expand window to match target size
+
+
+
+
+
+
+
+	parsedPacket, err := newParsedPacket(packet)
+	if err != nil {
+		// bad packet
+		return
+	}
+
+	if client := self.getPathClient(parsedPacket.ipPath); client != nil {
+		select {
+		case <- self.ctx.Done():
+			return
+		case client.Send() <- parsedPacket:
+			return
+		case <- time.After(WriteTimeout):
+			// now we can change the routing of this path
+			self.removePathClient(parsedPacket.ipPath, client)
+		}
+	}
+
+	for {
+		orderedClients, removedClients := self.window.OrderedClients(ExpandTimeout)
+		for _, client := range removedClients {
+			self.removeClient(client)
+		}
+
+		for _, client := range orderedClients {
+			select {
+			case client.Send() <- parsedPacket:
+				// lock the path to the client
+            	self.setPathClient(parsedPacket.ipPath, client)
+				return
+			default:
+			}
+		}
+
+        // select cases are in order:
+        // - self.ctx.Done
+        // - client writes...
+        // - timeout
+
+        selectCases := make([]reflect.SelectCase, 0, 2 + len(orderedClients))
+
+        // add the done case
+        doneIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(self.ctx.Done()),
+        })
+
+        // add all the clients
+        clientStartIndex := len(selectCases)
+        if 0 < len(orderedClients) {
+            sendValue := reflect.ValueOf(parsedPacket)
+            for _, client := range orderedClients {
+                selectCases = append(selectCases, reflect.SelectCase{
+                    Dir: reflect.SelectSend,
+                    Chan: reflect.ValueOf(client.Send()),
+                    Send: sendValue,
+                })
+            }
+        }
+
+        // add a timeout case
+        timeoutIndex := len(selectCases)
+        selectCases = append(selectCases, reflect.SelectCase{
+            Dir: reflect.SelectRecv,
+            Chan: reflect.ValueOf(time.After(MultiWriteTimeout)),
+        })
+
+        chosenIndex, _, _ := reflect.Select(selectCases)
+
+        switch chosenIndex {
+        case doneIndex:
+            // return errors.New("Done")
+            return
+        case timeoutIndex:
+            // return errors.New("Timeout")
+            return
+        default:
+            // a route
+            clientIndex := chosenIndex - clientStartIndex
+            client := orderedClients[clientIndex]
+            // lock the path to the client
+            self.setPathClient(parsedPacket.ipPath, client)
+			return
+        }
+	}
+}
+
+// `connect.ReceiveFunction`
+func (self *RemoteUserNatMultiClient) ClientReceive(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
+	// the client channels have already filtered the messages for the actual destinations only
+
+	source := Path{ClientId: sourceId}
+
+    for _, frame := range frames {
+        switch frame.MessageType {
+        case protocol.MessageType_IpIpPacketFromProvider:
+            ipPacketFromProvider_, err := FromFrame(frame)
+            if err != nil {
+                panic(err)
+            }
+            ipPacketFromProvider := ipPacketFromProvider_.(*protocol.IpPacketFromProvider)
+
+            fmt.Printf("remote user nat client r packet %s<-\n", source)
+
+            self.receivePacketCallback(source, IpProtocolUnknown, ipPacketFromProvider.IpPacket.PacketBytes)
+        }
+    }
+}
+
+
+
+
+// client send queue frame
+// don't read if max nack count <= nack count 
+// windowStats(dst), int and error
+
+
+
+
+type multiClientWindow struct {
+	ctx context.Context
+
+	specs []*ProviderSpec
+	receivePacketCallback ReceivePacketFunction
+
+	clientChannelArgs chan *multiClientChannelArgs
+
+	stateLock sync.Mutex
+	destinationClients map[Id]*multiClientChannel
+
+	windowUpdate *Monitor
+}
+
+func newMultiClientWindow(
+	ctx context.Context,
+	specs []*ProviderSpec,
+	receivePacketCallback ReceivePacketFunction,
+) *multiClientWindow {
+	window := &multiClientWindow{
+		ctx: ctx,
+		specs: specs,
+		receivePacketCallback: receivePacketCallback,
+		clientChannelArgs: make(chan *multiClientChannelArgs),
+		destinationClients: map[Id]*multiClientChannel{},
+	}
+
+	go window.randomEnumerateClientArgs()
+
+	return window
+}
+
+func (self *multiClientWindow) randomEnumerateClientArgs() {
+	// keep track of all client ids so far
+	// reset visited client ids if no new
+	visitedDestinationIds := map[Id]bool{}
+	for {
+
+		var destinationId Id
+		for {
+			nextDestinationIds := APINEXT(self.specs, maps.Keys(visitedDestinationIds), 1)
+			if 0 < len(nextDestinationIds) {
+				destinationId = nextDestinationIds[0]
+				visitedDestinationIds[destinationId] = true
+				break
+			}
+			// reset
+			visitedDestinationIds = map[Id]bool{}
+			select {
+			case <- self.ctx.Done():
+				return
+			case <- time.After(WindowEnumerateEmptyTimeout):
+			}
+		}
+
+		
+		// FIXME login client id
+		// FIXME are we parsing client id from the jwt locally?
+		// ParseByJwtUnverified
+		APILOGINCLIENT()
+
+		var clientId Id
+		clientAuth := &ClientAuth{}
+		args := &multiClientChannelArgs{
+			destinationId: destinationId,
+			clientId: clientId,
+			clientAuth: clientAuth,
+		} 
+
+		select {
+		case <- self.ctx.Done():
+			args.Close()
+			return
+		case self.clientChannelArgs <- args:
+		}
+	}
+}
+
+func (self *multiClientWindow) ExpandBy(expandStep int) {
+	self.stateLock.Lock()
+	windowSize := len(self.destinationClients)
+	self.stateLock.Unlock()
+
+	self.expandTo(windowSize + expandStep)
+}
+
+func (self *multiClientWindow) expandTo(targetWindowSize int) {
+	endTime := time.Now().Add(ExpandTimeout)
+	for {
+		update := self.windowUpdate.NotifyChannel()
+		self.stateLock.Lock()
+		windowSize := len(self.destinationClients)
+		self.stateLock.Unlock()
+
+		if targetWindowSize <= windowSize {
+			return
+		}
+
+		timeout := endTime.Sub(time.Now())
+		if timeout < 0 {
+			return
+		}
+
+		select {
+		case <- self.ctx.Done():
+			return
+		case <- update:
+			// continue
+		case args := <- self.clientChannelArgs:
+			self.stateLock.Lock()
+			client, ok := self.destinationClients[args.destinationId]
+			self.stateLock.Unlock()
+
+			if ok {
+				// already iterated this destination
+				args.Close()
+			} else {
+				client = newMultiClientChannel(self.ctx, args, self.receivePacketCallback)
+				self.stateLock.Lock()
+				self.destinationClients[args.destinationId] = client
+				self.stateLock.Unlock()
+				self.windowUpdate.NotifyAll()
+			}
+		case <- time.After(timeout):
+			return
+		}
+	}
+}
+
+func (self *multiClientWindow) OrderedClients(timeout time.Duration) ([]*multiClientChannel, []*multiClientChannel) {
+	self.stateLock.Lock()
+	clients := maps.Values(self.destinationClients)
+	self.stateLock.Unlock()
+
+	// expand
+	netSrcCount := 0
+	clientWeights := map[*multiClientChannel]float32{}
+	for _, client := range clients {
+		stats, err := client.windowStats()
+		if err != nil {
+			self.stateLock.Lock()
+			delete(self.destinationClients, client.destinationId)
+			self.stateLock.Unlock()
+			self.windowUpdate.NotifyAll()
+		} else {
+			netSrcCount += stats.srcCount
+			clientWeights[client] = float32(stats.netPacketCount)
+		}
+	}
+
+	targetWindowSize := minSize + netSrcCount * scale
+	expandTo(targetWindowSize)
+
+	// now order the clients based on the stats
+	WeightedShuffle(clients, clientWeight)
+
+	return clients
+}
+
+
+
+
+
+type multiClientChannelArgs struct {
+	destinationId Id
+	clientId Id
+	clientAuth *ClientAuth
+}
+
+func (self *multiClientChannelArgs) Close() {
+	// FIXME remove the client usind the api
+
+	APIREMOVECLIENT(self.clientId)
+}
+
+
+type multiClientEventType int
+const (
+	multiClientEventTypeAck multiClientEventType = 1
+	multiClientEventTypeNack multiClientEventType = 2
+	multiClientEventTypeError multiClientEventType = 3
+	multiClientEventTypeSrc multiClientEventType = 4
+)
+
+
+type multiClientEvent struct {
+	eventType multiClientEventType
+	ack bool
+	err error
+	ipPath *ipPath
+	eventTime time.Time
+}
+
+
+type clientWindowStats struct {
+	srcCount int
+	ackCount int
+	nackCount int
+	ackByteCount ByteCount
+	nackByteCount ByteCount
+}
+
+
+type multiClientChannel struct {
+	ctx context.Context
+	cancel context.CancelFunc
+
+	args *multiClientChannelArgs
+
+	send chan *parsedPacket
+
+	receivePacketCallback ReceivePacketFunction
+	sourceFilter map[Path]bool
+
+	client *Client
+
+	
+
+	stateLock sync.Mutex
+	events []*multiClientEvent
+	srcCount map[src]int
+	packetStats *clientWindowStats
+	endErr error
+
+	maxNackCount int
+
+	eventUpdate *Monitor
+}
+
+func newMultiClientChannel(
+	ctx context.Context,
+	args *multiClientChannelArgs,
+	receivePacketCallback ReceivePacketFunction,
+) *multiClientChannel {
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+
+	client := NewClientWithDefaults(cancelCtx)
+
+	transport := NewPlatformaTransport(cancelCtx, args.clientAuth, client.RouteManager())
+
+
+
+	sourceFilter := map[Path]bool{
+		args.destinationId: true,
+	}
+
+    clientChannel := &multiClientChannel{
+    	ctx: cancelCtx,
+    	cancel: cancel,
+    	args: args,
+    	send: make(chan *parsedPacket),
+    	receivePacketCallback: receivePacketCallback,
+    	sourceFilter: sourceFilter,
+    	client: client,
+    	events: []*multiClientEvent{},
+		srcCount: map[src]int{},
+		packetStats: &clientWindowStats{},
+		endErr: nil,
+    }
+
+
+	go clientChannel.run()
+
+	client.AddReceiveCallback(clientChannel)
+
+	return client
+}
+
+
+func (self *multiClientChannel) run() {
+	defer func() {
+		self.cancel()
+		self.addError(errors.New("Done."))
+		self.args.Close()
+	}()
+
+	for {
+		update := self.eventUpdate.NotifyChannel()
+		if self.isMaxAcks() {
+			select {
+			case <- self.ctx.Done():
+				return
+			case <- update:
+			}
+		} else {
+			select {
+			case <- self.ctx.Done():
+				return
+			case parsedPacket := <- self.send:
+				self.addNack()
+				self.addSrc(parsedPacket.ipPath)
+				success := self.client.SendWithTimeout(frame, destinationId, func(error) {
+					if err == nil {
+						self.addAck()
+					} else {
+						self.addError(err)
+						return
+					}
+				})
+				if !success {
+					self.addError(errors.New("Send failed."))
+				}
+			}
+		}
+	}
+}
+
+
+func (self *multiClientChannel) Send() chan *parsedPacket {
+	return self.send
+}
+
+
+func (self *multiClientChannel) isMaxAcks() {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	return (self.maxNackCount <= self.packetStats.nackCount)
+}
+
+
+func (self *multiClientChannel) addNack() {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.events = append(self.events, &multiClientEvent{
+		eventType: multiClientEventTypeAck,
+		ack: false,
+	})
+}
+
+func (self *multiClientChannel) addAck() {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.events = append(self.events, &multiClientEvent{
+		eventType: multiClientEventTypeAck,
+		ack: true,
+	})
+}
+
+func (self *multiClientChannel) addSrc(ipPath *ipPath) {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.events = append(self.events, &multiClientEvent{
+		eventType: multiClientEventTypeSrc,
+		ipPath: ipPath,
+	})
+}
+
+func (self *multiClientChannel) addError(err error) {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.events = append(self.events, &multiClientEvent{
+		eventType: multiClientEventTypeError,
+		err: err,
+	})
+}
+
+
+
+
+func (self *multiClientChannel) windowStats() (*clientWindowStats, error) {
+	
+	changed := false
+	self.stateLock.Lock()
+	// forward the event window
+	i := 0
+	for i < len(self.events) {
+		event := self.events[i]
+		if now < event.eventTime {
+			break
+		}
+		switch event.eventType {
+		case Nack:
+			self.packetStats.nackCount += 1
+			changed = true
+
+		case Ack:
+			self.packetStats.nackCount -= 1
+			self.packetStats.ackCount += 1
+			self.maxNackCount = min(self.maxNackCount + NACKSCALE, MAXNACKCOUNT)
+			changed = true
+
+		case Src:
+			self.srcCount[ipPath.Src()] += 1
+			changed = true
+
+		case Error:
+			if self.endErr == nil {
+				self.endErr = err
+				changed = true
+			}
+		}
+		self.events[i] = nil
+	}
+	self.events = self.events[:i]
+
+	out := &clientWindowStats{
+		srcCount: len(self.srcCount),
+		ackCount: self.packetStats.ackCount,
+		nackCount: self.packetStats.nackCount,
+		ackByteCount: self.packetStats.ackByteCount,
+		nackByteCount: self.packetStats.nackByteCount,
+	}
+	outErr := self.endErr
+
+	self.stateLock.Unlock()
+
+	if changed {
+		self.eventUpdate.NotifyAll()
+	}
+
+	return out, outErr
+}
+
+
+func (self *multiClientChannel) ClientReceive(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
+	source := Path{ClientId: sourceId}
+
+    // only process frames from the destinations
+    if allow := self.sourceFilter[source]; !allow {
+        return
+    }
+
+    self.receivePacketCallback(sourceId, frames, provideMode)
+}
+
+
+
+
+
+func APINEXT(specs []*ProviderSpec, excludeClientIds []Id, count int) []Id {
+	// FIXME
+	return []Id{}
+}
+
+
+func APILOGINCLIENT() {
+	// FIXME
+}
+
+
+func APIREMOVECLIENT(clientId Id) {
+	// FIXME
+}
+
+
+
+
+

--- a/connect/ip_remote_multi_client.go
+++ b/connect/ip_remote_multi_client.go
@@ -670,27 +670,27 @@ func (self *multiClientWindow) resize() {
                 float64(netSourceCount) * self.settings.WindowSizeReconnectScale,
             )),
         )
-        fmt.Printf("[multi] Resize ->%d\n", targetWindowSize)
+        // fmt.Printf("[multi] Resize ->%d\n", targetWindowSize)
 
         if len(clients) < targetWindowSize {
             // expand
 
             n := targetWindowSize - len(clients)
-            fmt.Printf("[multi] Expand +%d\n", n)
+            fmt.Printf("[multi] Expand +%d ->%d\n", n, targetWindowSize)
             
             self.expand(n)
         } else if targetWindowSize < len(clients) {
             // collapse the lowest weighted
             
             n := len(clients) - targetWindowSize
-            fmt.Printf("[multi] Collapse -%d\n", n)
+            fmt.Printf("[multi] Collapse -%d ->%d\n", n, targetWindowSize)
 
             for _, client := range clients[targetWindowSize:] {
                 client.Cancel()
             }
             clients = clients[:targetWindowSize]
         } else if q3 := 3 * len(clients) / 4; q3 + 1 < len(clients) {
-            // optimize by removing unused from the lowest quartile
+            // optimize by removing unused from q4
 
             n := 0
 
@@ -706,7 +706,9 @@ func (self *multiClientWindow) resize() {
                 }
             }
 
-            fmt.Printf("[multi] Optimize -%d\n", n)
+            if 0 < n {
+                fmt.Printf("[multi] Optimize -%d\n", n)
+            }
         }
 
         select {

--- a/connect/ip_remote_multi_client.go
+++ b/connect/ip_remote_multi_client.go
@@ -53,7 +53,7 @@ func DefaultMultiClientSettings() *MultiClientSettings {
         AckTimeout: 5 * time.Second,
         WindowResizeTimeout: 1 * time.Second,
         StatsWindowGraceperiod: 5 * time.Second,
-        StatsWindowEntropy: 0.05,
+        StatsWindowEntropy: 0.25,
         WindowExpandTimeout: 2 * time.Second,
         WindowEnumerateEmptyTimeout: 1 * time.Second,
         WindowEnumerateErrorTimeout: 1 * time.Second,

--- a/connect/ip_remote_multi_client_test.go
+++ b/connect/ip_remote_multi_client_test.go
@@ -1,22 +1,132 @@
 package connect
 
+import (
+	"context"
+    "testing"
+    // "time"
+    // mathrand "math/rand"
+    // "fmt"
+    // "crypto/hmac"
+	// "crypto/sha256"
+	// "sync"
+	"slices"
+	// "bytes"
+	// "encoding/binary"
+	// "net"
+	// "reflect"
+	// "fmt"
+	// "sync"
+
+	// "github.com/google/gopacket"
+    // "github.com/google/gopacket/layers"
+
+	// "google.golang.org/protobuf/proto"
+
+    // "github.com/go-playground/assert/v2"
+
+    // "bringyour.com/protocol"
+)
 
 
-/*
-func TestMultiClient() {
 
-
-	// n destinations
-	// all have the same receiver callback, put into a channel of messages
-	// echo the received packet
-
-	// create fake ip4 packets to 72.i.j.k for all iterations of i,j,k in a range
-	// randomly retransmit some packets by increasing source port
-	// make sure all packets are received
-	// make sure all packets are echoed back
-
-
-
-
+func TestMultiClientUdp4(t *testing.T) {
+	testClient(t, testingNewMultiClient, udp4Packet, (*IpPath).ToIp4Path)
 }
-*/
+
+func TestMultiClientTcp4(t *testing.T) {
+	testClient(t, testingNewMultiClient, tcp4Packet, (*IpPath).ToIp4Path)
+}
+
+func TestMultiClientUdp6(t *testing.T) {
+	testClient(t, testingNewMultiClient, udp6Packet, (*IpPath).ToIp6Path)
+}
+
+func TestMultiClientTcp6(t *testing.T) {
+	testClient(t, testingNewMultiClient, tcp6Packet, (*IpPath).ToIp6Path)
+}
+
+
+
+func testingNewMultiClient(ctx context.Context, providerClient *Client, receivePacketCallback ReceivePacketFunction) (UserNatClient, error) {
+
+	
+	generator := &TestMultiClientGenerator{
+		nextDestintationIds: func(count int, excludedClientIds []Id) (map[Id]ByteCount, error) {
+			next := map[Id]ByteCount{}
+			if !slices.Contains(excludedClientIds, providerClient.ClientId()) {
+				 next[providerClient.ClientId()] = ByteCount(0)
+			}
+			return next, nil
+		},
+	    newClientArgs: func()(*MultiClientGeneratorClientArgs, error) {
+	    	args := &MultiClientGeneratorClientArgs{
+	    		ClientId: NewId(),
+				ClientAuth: nil,
+			}
+			return args, nil
+	    },
+	    removeClientArgs: func(args *MultiClientGeneratorClientArgs) {
+	    	// do nothing
+	    },
+	    newClient: func(ctx context.Context, args *MultiClientGeneratorClientArgs, clientSettings *ClientSettings) (*Client, error) {
+	    	client := NewClientWithDefaults(ctx, args.ClientId)
+
+	    	routesSend := []Route{
+				make(chan []byte),
+			}
+			routesReceive := []Route{
+				make(chan []byte),
+			}
+
+	    	transportSend := NewSendGatewayTransport()
+			transportReceive := NewReceiveGatewayTransport()
+			client.RouteManager().UpdateTransport(transportSend, routesSend)
+			client.RouteManager().UpdateTransport(transportReceive, routesReceive)
+
+			providerTransportSend := NewSendClientTransport(args.ClientId)
+			providerTransportReceive := NewReceiveGatewayTransport()
+			providerClient.RouteManager().UpdateTransport(providerTransportReceive, routesSend)
+			providerClient.RouteManager().UpdateTransport(providerTransportSend, routesReceive)
+			
+
+			return client, nil
+	    },
+	}
+
+
+	multiClient := NewRemoteUserNatMultiClientWithDefaults(
+		ctx,
+		generator,
+		receivePacketCallback,
+	)
+
+	return multiClient, nil
+
+
+	
+}
+
+
+type TestMultiClientGenerator struct {
+	nextDestintationIds func(count int, excludedClientIds []Id) (map[Id]ByteCount, error)
+    newClientArgs func()(*MultiClientGeneratorClientArgs, error)
+    removeClientArgs func(args *MultiClientGeneratorClientArgs)
+    newClient func(ctx context.Context, args *MultiClientGeneratorClientArgs, clientSettings *ClientSettings) (*Client, error)
+}
+
+func (self *TestMultiClientGenerator) NextDestintationIds(count int, excludedClientIds []Id) (map[Id]ByteCount, error) {
+	return self.nextDestintationIds(count, excludedClientIds)
+}
+
+func (self *TestMultiClientGenerator) NewClientArgs() (*MultiClientGeneratorClientArgs, error) {
+	return self.newClientArgs()
+}
+
+func (self *TestMultiClientGenerator) RemoveClientArgs(args *MultiClientGeneratorClientArgs) {
+	self.removeClientArgs(args)
+}
+
+func (self *TestMultiClientGenerator) NewClient(ctx context.Context, args *MultiClientGeneratorClientArgs, clientSettings *ClientSettings) (*Client, error) {
+	return self.newClient(ctx, args, clientSettings)
+}
+

--- a/connect/ip_remote_multi_client_test.go
+++ b/connect/ip_remote_multi_client_test.go
@@ -1,0 +1,21 @@
+package connect
+
+
+
+
+func TestMultiClient() {
+
+
+	// n destinations
+	// all have the same receiver callback, put into a channel of messages
+	// echo the received packet
+
+	// create fake ip4 packets to 72.i.j.k for all iterations of i,j,k in a range
+	// randomly retransmit some packets by increasing source port
+	// make sure all packets are received
+	// make sure all packets are echoed back
+
+
+
+
+}

--- a/connect/ip_remote_multi_client_test.go
+++ b/connect/ip_remote_multi_client_test.go
@@ -2,7 +2,7 @@ package connect
 
 
 
-
+/*
 func TestMultiClient() {
 
 
@@ -19,3 +19,4 @@ func TestMultiClient() {
 
 
 }
+*/

--- a/connect/ip_remote_multi_client_test.go
+++ b/connect/ip_remote_multi_client_test.go
@@ -4,48 +4,31 @@ import (
 	"context"
     "testing"
     "time"
-    // mathrand "math/rand"
     "math"
-    // "fmt"
-    // "crypto/hmac"
-	// "crypto/sha256"
-	// "sync"
-	"slices"
-	// "bytes"
-	// "encoding/binary"
-	// "net"
-	// "reflect"
-	// "fmt"
-	// "sync"
-
-	// "github.com/google/gopacket"
-    // "github.com/google/gopacket/layers"
-
-	// "google.golang.org/protobuf/proto"
+    "slices"
 
     "github.com/go-playground/assert/v2"
-
-    // "bringyour.com/protocol"
 )
-
 
 
 func TestMultiClientUdp4(t *testing.T) {
 	testClient(t, testingNewMultiClient, udp4Packet, (*IpPath).ToIp4Path)
 }
 
+
 func TestMultiClientTcp4(t *testing.T) {
 	testClient(t, testingNewMultiClient, tcp4Packet, (*IpPath).ToIp4Path)
 }
+
 
 func TestMultiClientUdp6(t *testing.T) {
 	testClient(t, testingNewMultiClient, udp6Packet, (*IpPath).ToIp6Path)
 }
 
+
 func TestMultiClientTcp6(t *testing.T) {
 	testClient(t, testingNewMultiClient, tcp6Packet, (*IpPath).ToIp6Path)
 }
-
 
 
 func testingNewMultiClient(ctx context.Context, providerClient *Client, receivePacketCallback ReceivePacketFunction) (UserNatClient, error) {	
@@ -166,8 +149,8 @@ func TestMultiClientChannelWindowStats(t *testing.T) {
 	}
 
 	settings := DefaultMultiClientSettings()
-	settings.StatsWindowBucketDuration = 1 * time.Millisecond
-	settings.StatsWindowDuration = 10 * time.Millisecond
+	settings.StatsWindowBucketDuration = 100 * time.Millisecond
+	settings.StatsWindowDuration = 1 * time.Second
 
 	// the coalesce logic trims from the last event in a bucket
 	// if events are uniformly distributed in a bucket, this means there will be an extra bucket

--- a/connect/ip_test.go
+++ b/connect/ip_test.go
@@ -433,11 +433,11 @@ func testClient[P comparable](
 ) {
 	timeout := 30 * time.Second
 
-	m := 4
-	n := 4
-	repeatCount := 4
-	parallelCount := 4
-	echoCount := 0
+	m := 6
+	n := 6
+	repeatCount := 6
+	parallelCount := 6
+	echoCount := 2
 
 
 

--- a/connect/ip_test.go
+++ b/connect/ip_test.go
@@ -4,23 +4,13 @@ import (
 	"context"
     "testing"
     "time"
-    // mathrand "math/rand"
-    // "fmt"
-    // "crypto/hmac"
-	// "crypto/sha256"
-	// "sync"
-	// "slices"
-	// "bytes"
 	"encoding/binary"
 	"net"
 	"reflect"
-	// "fmt"
 	"sync"
 
 	"github.com/google/gopacket"
     "github.com/google/gopacket/layers"
-
-	// "google.golang.org/protobuf/proto"
 
     "github.com/go-playground/assert/v2"
 
@@ -28,27 +18,121 @@ import (
 )
 
 
-
-
-// test ippath parsing
-
-// FIXME
-// TestUdp6Path
-// TestTcp6Path
-
-
 type PacketGeneratorFunction func(int, int, int, int)([]byte, []byte)
 
 
+func TestUdp4Path(t *testing.T) {
+	packet, _ := udp4Packet(1, 1, 1, 1)
+	ipPath, err := ParseIpPath(packet)
+	assert.Equal(t, nil, err)
+
+	assert.Equal(t, IpProtocolUdp, ipPath.Protocol)
+
+	assert.Equal(t, &IpPath{
+		Version: 4,
+		Protocol: IpProtocolUdp,
+	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4(),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4(),
+	    DestinationPort: 443,
+	}, ipPath)
+
+	ip4Path := ipPath.ToIp4Path()
+	assert.Equal(t, Ip4Path{
+		Protocol: IpProtocolUdp,
+	    SourceIp: [4]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4()),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: [4]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4()),
+	    DestinationPort: 443,
+	}, ip4Path)
+}
+
+
+func TestTcp4Path(t *testing.T) {
+	packet, _ := tcp4Packet(1, 1, 1, 1)
+	ipPath, err := ParseIpPath(packet)
+	assert.Equal(t, nil, err)
+
+	assert.Equal(t, IpProtocolTcp, ipPath.Protocol)
+
+	assert.Equal(t, &IpPath{
+		Version: 4,
+		Protocol: IpProtocolTcp,
+	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4(),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4(),
+	    DestinationPort: 443,
+	}, ipPath)
+
+	ip4Path := ipPath.ToIp4Path()
+	assert.Equal(t, Ip4Path{
+		Protocol: IpProtocolTcp,
+	    SourceIp: [4]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4()),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: [4]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4()),
+	    DestinationPort: 443,
+	}, ip4Path)
+}
+
+
+func TestUdp6Path(t *testing.T) {
+	packet, _ := udp6Packet(1, 1, 1, 1)
+	ipPath, err := ParseIpPath(packet)
+	assert.Equal(t, nil, err)
+
+	assert.Equal(t, IpProtocolUdp, ipPath.Protocol)
+
+	assert.Equal(t, &IpPath{
+		Version: 6,
+		Protocol: IpProtocolUdp,
+	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16(),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16(),
+	    DestinationPort: 443,
+	}, ipPath)
+
+	ip6Path := ipPath.ToIp6Path()
+	assert.Equal(t, Ip6Path{
+		Protocol: IpProtocolUdp,
+	    SourceIp: [16]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16()),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: [16]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16()),
+	    DestinationPort: 443,
+	}, ip6Path)
+}
+
+
+func TestTcp6Path(t *testing.T) {
+	packet, _ := tcp6Packet(1, 1, 1, 1)
+	ipPath, err := ParseIpPath(packet)
+	assert.Equal(t, nil, err)
+
+	assert.Equal(t, IpProtocolTcp, ipPath.Protocol)
+
+	assert.Equal(t, &IpPath{
+		Version: 6,
+		Protocol: IpProtocolTcp,
+	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16(),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16(),
+	    DestinationPort: 443,
+	}, ipPath)
+
+	ip6Path := ipPath.ToIp6Path()
+	assert.Equal(t, Ip6Path{
+		Protocol: IpProtocolTcp,
+	    SourceIp: [16]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16()),
+	    SourcePort: 40000 + 1,
+	    DestinationIp: [16]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16()),
+	    DestinationPort: 443,
+	}, ip6Path)
+}
+
+
+
 func udp4Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
-
-	// b := &bytes.Buffer{}
-	// binary.Write(b, binary.LittleEndian, s)
-	// payload = b.Bytes()
-
 	payload = make([]byte, 4)
     binary.LittleEndian.PutUint32(payload, uint32(s))
-
 
 	sourceIp := net.IPv4(72, 0, 0, 1)
 	sourcePort := layers.UDPPort(40000 + s)
@@ -90,14 +174,8 @@ func udp4Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
 
 
 func tcp4Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
-
-	// b := &bytes.Buffer{}
-	// binary.Write(b, binary.LittleEndian, s)
-	// payload = b.Bytes()
-
 	payload = make([]byte, 4)
     binary.LittleEndian.PutUint32(payload, uint32(s))
-
 
 	sourceIp := net.IPv4(72, 0, 0, 1)
 	sourcePort := layers.TCPPort(40000 + s)
@@ -142,14 +220,8 @@ func tcp4Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
 
 
 func udp6Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
-
-	// b := &bytes.Buffer{}
-	// binary.Write(b, binary.LittleEndian, s)
-	// payload = b.Bytes()
-
 	payload = make([]byte, 4)
     binary.LittleEndian.PutUint32(payload, uint32(s))
-
 
 	sourceIp := net.IPv4(72, 0, 0, 1).To16()
 	sourcePort := layers.UDPPort(40000 + s)
@@ -190,16 +262,9 @@ func udp6Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
 }
 
 
-
 func tcp6Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
-
-	// b := &bytes.Buffer{}
-	// binary.Write(b, binary.LittleEndian, s)
-	// payload = b.Bytes()
-
 	payload = make([]byte, 4)
     binary.LittleEndian.PutUint32(payload, uint32(s))
-
 
 	sourceIp := net.IPv4(72, 0, 0, 1).To16()
 	sourcePort := layers.TCPPort(40000 + s)
@@ -243,148 +308,20 @@ func tcp6Packet(s int, i int, j int, k int)(packet []byte, payload []byte) {
 }
 
 
-func TestUdp4Path(t *testing.T) {
-
-
-
-	packet, _ := udp4Packet(1, 1, 1, 1)
-	ipPath, err := ParseIpPath(packet)
-	assert.Equal(t, nil, err)
-
-	assert.Equal(t, IpProtocolUdp, ipPath.Protocol)
-
-	assert.Equal(t, &IpPath{
-		Version: 4,
-		Protocol: IpProtocolUdp,
-	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4(),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4(),
-	    DestinationPort: 443,
-	}, ipPath)
-
-	ip4Path := ipPath.ToIp4Path()
-	assert.Equal(t, Ip4Path{
-		Protocol: IpProtocolUdp,
-	    SourceIp: [4]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4()),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: [4]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4()),
-	    DestinationPort: 443,
-	}, ip4Path)
-
-
-}
-
-
-func TestTcp4Path(t *testing.T) {
-
-
-
-	packet, _ := tcp4Packet(1, 1, 1, 1)
-	ipPath, err := ParseIpPath(packet)
-	assert.Equal(t, nil, err)
-
-	assert.Equal(t, IpProtocolTcp, ipPath.Protocol)
-
-	assert.Equal(t, &IpPath{
-		Version: 4,
-		Protocol: IpProtocolTcp,
-	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4(),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4(),
-	    DestinationPort: 443,
-	}, ipPath)
-
-	ip4Path := ipPath.ToIp4Path()
-	assert.Equal(t, Ip4Path{
-		Protocol: IpProtocolTcp,
-	    SourceIp: [4]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To4()),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: [4]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To4()),
-	    DestinationPort: 443,
-	}, ip4Path)
-
-
-}
-
-
-
-func TestUdp6Path(t *testing.T) {
-
-
-
-	packet, _ := udp6Packet(1, 1, 1, 1)
-	ipPath, err := ParseIpPath(packet)
-	assert.Equal(t, nil, err)
-
-	assert.Equal(t, IpProtocolUdp, ipPath.Protocol)
-
-	assert.Equal(t, &IpPath{
-		Version: 6,
-		Protocol: IpProtocolUdp,
-	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16(),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16(),
-	    DestinationPort: 443,
-	}, ipPath)
-
-	ip6Path := ipPath.ToIp6Path()
-	assert.Equal(t, Ip6Path{
-		Protocol: IpProtocolUdp,
-	    SourceIp: [16]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16()),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: [16]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16()),
-	    DestinationPort: 443,
-	}, ip6Path)
-
-
-}
-
-
-func TestTcp6Path(t *testing.T) {
-
-
-
-	packet, _ := tcp6Packet(1, 1, 1, 1)
-	ipPath, err := ParseIpPath(packet)
-	assert.Equal(t, nil, err)
-
-	assert.Equal(t, IpProtocolTcp, ipPath.Protocol)
-
-	assert.Equal(t, &IpPath{
-		Version: 6,
-		Protocol: IpProtocolTcp,
-	    SourceIp: net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16(),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16(),
-	    DestinationPort: 443,
-	}, ipPath)
-
-	ip6Path := ipPath.ToIp6Path()
-	assert.Equal(t, Ip6Path{
-		Protocol: IpProtocolTcp,
-	    SourceIp: [16]byte(net.IPv4(byte(72), byte(0), byte(0), byte(1)).To16()),
-	    SourcePort: 40000 + 1,
-	    DestinationIp: [16]byte(net.IPv4(byte(72), byte(1 + 1), byte(1 + 1), byte(1 + 1)).To16()),
-	    DestinationPort: 443,
-	}, ip6Path)
-
-
-}
-
-
-// FIXME TestClientTcp
-
 func TestClientUdp4(t *testing.T) {
 	testClient(t, testingNewClient, udp4Packet, (*IpPath).ToIp4Path)
 }
+
 
 func TestClientTcp4(t *testing.T) {
 	testClient(t, testingNewClient, tcp4Packet, (*IpPath).ToIp4Path)
 }
 
+
 func TestClientUdp6(t *testing.T) {
 	testClient(t, testingNewClient, udp6Packet, (*IpPath).ToIp6Path)
 }
+
 
 func TestClientTcp6(t *testing.T) {
 	testClient(t, testingNewClient, tcp6Packet, (*IpPath).ToIp6Path)
@@ -392,7 +329,6 @@ func TestClientTcp6(t *testing.T) {
 
 
 func testingNewClient(ctx context.Context, providerClient *Client, receivePacketCallback ReceivePacketFunction) (UserNatClient, error) {
-
 	client := NewClientWithDefaults(ctx, NewId())
 
 	routesSend := []Route{
@@ -420,9 +356,7 @@ func testingNewClient(ctx context.Context, providerClient *Client, receivePacket
 		},
 		protocol.ProvideMode_Network,
 	)
-	
 }
-
 
 
 func testClient[P comparable](
@@ -431,6 +365,20 @@ func testClient[P comparable](
 	packetGenerator PacketGeneratorFunction,
 	toComparableIpPath func(*IpPath)(P),
 ) {
+	// runs a send-receive test on the `UserNatClient` produced by `userNatClientGenerator`
+	// this is a multi-threaded stress test that is meant to stress the buffers and routing
+
+
+	// n destinations
+	// all have the same receiver callback, put into a channel of messages
+	// echo the received packet
+
+	// create fake packets for all iterations of i,j,k in a range
+	// retransmit some packets by increasing source port s
+	// make sure all packets are received
+	// make sure all packets are echoed back
+
+
 	timeout := 30 * time.Second
 
 	m := 6
@@ -438,7 +386,6 @@ func testClient[P comparable](
 	repeatCount := 6
 	parallelCount := 6
 	echoCount := 2
-
 
 
 	// each packet gets echoed back
@@ -449,31 +396,14 @@ func testClient[P comparable](
 	cReceiveCount := 0
 
 
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	// n destinations
-	// all have the same receiver callback, put into a channel of messages
-	// echo the received packet
-
-	// create fake ip4 packets to 72.i.j.k for all iterations of i,j,k in a range
-	// randomly retransmit some packets by increasing source port
-	// make sure all packets are received
-	// make sure all packets are echoed back
-
-	
-
 
 	clientId := NewId()
 	providerClientId := NewId()
 
 
 	providerClient := NewClientWithDefaults(ctx, providerClientId)
-
-
-
-
 
 
 	type receivePacket struct {
@@ -503,9 +433,6 @@ func testClient[P comparable](
 
 	natClient, err := userNatClientGenerator(ctx, providerClient, receivePacketCallback)
 	assert.Equal(t, err, nil)
-
-
-
 
 
 	providerClient.AddReceiveCallback(func(sourceId Id, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
@@ -554,9 +481,6 @@ func testClient[P comparable](
 
         }
 	})
-
-
-
 
 
 	for p := 0; p < parallelCount; p += 1 {
@@ -619,17 +543,8 @@ func testClient[P comparable](
 	            payload = tcp.Payload
 			}
 
-
-			// fmt.Printf("GOT %d PAYLOAD %v (%d)\n", ipPath.Protocol, payload, len(payload))
-
-
-			
-				// ip4Path := ipPath.ToIp4Path()
 			comparableIpPath := toComparableIpPath(ipPath)
-
-
 			comparableIpPathPayloads[comparableIpPath] = append(comparableIpPathPayloads[comparableIpPath], payload)
-
 
 			sources, ok := comparableIpPathSources[comparableIpPath]
 			if !ok {
@@ -656,12 +571,9 @@ func testClient[P comparable](
 
 					payloads := comparableIpPathPayloads[comparableIpPath]
 
-					// fmt.Printf("PAYLOADS %v <> %v\n", payload, payloads)
-
 					count := 0
 					for _, b := range payloads {
 						e := reflect.DeepEqual(b, payload)
-						// fmt.Printf("DEEP EQUAL %v (%d %T) <> %v (%d %T) %t\n", b, len(b), b, payload, len(payload), payload, e)
 						if e {
 							count += 1
 						}
@@ -680,8 +592,6 @@ func testClient[P comparable](
 			}
 		}
 	}
-
-
 }
 
 

--- a/connect/jwt.go
+++ b/connect/jwt.go
@@ -15,12 +15,7 @@ type ByJwt struct {
 }
 
 
-func ParseByJwtUnverified(jwt string) (*ByJwt, error) {
-	byJwtStr, err := self.GetByJwt()
-	if err != nil {
-		return nil, err
-	}
-
+func ParseByJwtUnverified(byJwtStr string) (*ByJwt, error) {
 	parser := gojwt.NewParser()
 	token, _, err := parser.ParseUnverified(byJwtStr, gojwt.MapClaims{})
 	if err != nil {
@@ -32,7 +27,7 @@ func ParseByJwtUnverified(jwt string) (*ByJwt, error) {
 	byJwt := &ByJwt{}
 
 	if userIdStr, ok := claims["user_id"]; ok {
-		if userId, err := NewIdFromString(userIdStr.(string)); err == nil {
+		if userId, err := ParseId(userIdStr.(string)); err == nil {
 			byJwt.UserId = userId
 		}
 	}
@@ -40,12 +35,12 @@ func ParseByJwtUnverified(jwt string) (*ByJwt, error) {
 		byJwt.NetworkName = networkName.(string)
 	}
 	if networkIdStr, ok := claims["network_name"]; ok {
-		if networkId, err := NewIdFromString(networkIdStr.(string)); err == nil {
+		if networkId, err := ParseId(networkIdStr.(string)); err == nil {
 			byJwt.NetworkId = networkId
 		}
 	}
 	if clientIdStr, ok := claims["client_id"]; ok {
-		if clientId, err := NewIdFromString(clientIdStr.(string)); err == nil {
+		if clientId, err := ParseId(clientIdStr.(string)); err == nil {
 			byJwt.ClientId = clientId
 		}
 	}

--- a/connect/jwt.go
+++ b/connect/jwt.go
@@ -1,0 +1,55 @@
+package connect
+
+import (
+
+	gojwt "github.com/golang-jwt/jwt/v5"
+)
+
+
+
+type ByJwt struct {
+	UserId Id
+	NetworkName string
+	NetworkId Id
+	ClientId Id
+}
+
+
+func ParseByJwtUnverified(jwt string) (*ByJwt, error) {
+	byJwtStr, err := self.GetByJwt()
+	if err != nil {
+		return nil, err
+	}
+
+	parser := gojwt.NewParser()
+	token, _, err := parser.ParseUnverified(byJwtStr, gojwt.MapClaims{})
+	if err != nil {
+		return nil, err
+	}
+
+	claims := token.Claims.(gojwt.MapClaims)
+
+	byJwt := &ByJwt{}
+
+	if userIdStr, ok := claims["user_id"]; ok {
+		if userId, err := NewIdFromString(userIdStr.(string)); err == nil {
+			byJwt.UserId = userId
+		}
+	}
+	if networkName, ok := claims["network_name"]; ok {
+		byJwt.NetworkName = networkName.(string)
+	}
+	if networkIdStr, ok := claims["network_name"]; ok {
+		if networkId, err := NewIdFromString(networkIdStr.(string)); err == nil {
+			byJwt.NetworkId = networkId
+		}
+	}
+	if clientIdStr, ok := claims["client_id"]; ok {
+		if clientId, err := NewIdFromString(clientIdStr.(string)); err == nil {
+			byJwt.ClientId = clientId
+		}
+	}
+
+	return byJwt, nil
+}
+

--- a/connect/log.go
+++ b/connect/log.go
@@ -8,7 +8,7 @@ import (
 
 
 // Logging convention in the `connect` package and generally for BringYour network components:
-// Info: 
+// Info:
 //     essential events for abnormal behavior. This level should be silent on normal operation,
 //     with the exception of one time (infrequent) initialization data that is useful for monitoring
 //     this includes:
@@ -19,12 +19,16 @@ import (
 //     this includes:
 //     - unexpected panics even if handled and suppressed for partial operation
 // Debug:
+//     [glog V(1)]
 //     key events for trace debuggung and statistics
 //     this includes:
 //     - key system events with ids that can be used to filter
 //     - frequent events - e.g. send, retry, forward, receive, ack - 
 //       should be summarized as statistics printed every "n seconds" 
 //       rather than logging each individual data point
+//     [glog V(2)]
+//     specific use-case logging
+
 
 
 const LogLevelUrgent = 0

--- a/connect/transfer.go
+++ b/connect/transfer.go
@@ -84,7 +84,7 @@ func DefaultSendBufferSettings() *SendBufferSettings {
 		ResendInterval: 2 * time.Second,
 		// no backoff
 		ResendBackoffScale: 0.0,
-		AckTimeout: 300 * time.Second,
+		AckTimeout: 60 * time.Second,
 		IdleTimeout: 300 * time.Second,
 		// pause on resend for selectively acked messaged
 		SelectiveAckTimeout: 15 * time.Second,

--- a/connect/transfer.go
+++ b/connect/transfer.go
@@ -2009,16 +2009,12 @@ func (self *ReceiveSequence) receive(receivePack *ReceivePack) (bool, error) {
 	}
 
 
+	// this case happens when the receiver is reformed or loses state.
+	// the sequence id guarantees the sender is the same for the sequence
+	// past head items are retransmits. Future head items depend on previous ack,
+	// which represent some state the sender has that the receiver is missing
+	// advance the receiver state to the latest from the sender
 	if item.head && self.nextSequenceNumber < item.sequenceNumber {
-		// remove earlier items in the receive queue
-		for {
-			first := self.receiveQueue.PeekFirst()
-			if first == nil || item.sequenceNumber < first.sequenceNumber {
-				break
-			}
-			self.receiveQueue.RemoveBySequenceNumber(first.sequenceNumber)
-		}
-
 		transferLog("HEAD ADVANCE %d -> %d\n", self.nextSequenceNumber, item.sequenceNumber)
 		self.nextSequenceNumber = item.sequenceNumber
 	}

--- a/connect/transfer.go
+++ b/connect/transfer.go
@@ -394,21 +394,27 @@ func (self *Client) forward(sourceId Id, destinationId Id, transferFrameBytes []
 	}
 }
 
-func (self *Client) AddReceiveCallback(receiveCallback ReceiveFunction) {
-	self.receiveCallbacks.Add(receiveCallback)
+func (self *Client) AddReceiveCallback(receiveCallback ReceiveFunction) func() {
+	callbackId := self.receiveCallbacks.Add(receiveCallback)
+	return func() {
+		self.receiveCallbacks.Remove(callbackId)
+	}
 }
 
-func (self *Client) RemoveReceiveCallback(receiveCallback ReceiveFunction) {
-	self.receiveCallbacks.Remove(receiveCallback)
+// func (self *Client) RemoveReceiveCallback(receiveCallback ReceiveFunction) {
+// 	self.receiveCallbacks.Remove(receiveCallback)
+// }
+
+func (self *Client) AddForwardCallback(forwardCallback ForwardFunction) func() {
+	callbackId := self.forwardCallbacks.Add(forwardCallback)
+	return func() {
+		self.forwardCallbacks.Remove(callbackId)
+	}
 }
 
-func (self *Client) AddForwardCallback(forwardCallback ForwardFunction) {
-	self.forwardCallbacks.Add(forwardCallback)
-}
-
-func (self *Client) RemoveForwardCallback(forwardCallback ForwardFunction) {
-	self.forwardCallbacks.Remove(forwardCallback)
-}
+// func (self *Client) RemoveForwardCallback(forwardCallback ForwardFunction) {
+// 	self.forwardCallbacks.Remove(forwardCallback)
+// }
 
 func (self *Client) run() {
 	defer self.cancel()

--- a/connect/transfer_queue_test.go
+++ b/connect/transfer_queue_test.go
@@ -27,7 +27,7 @@ func TestTransferQueue(t *testing.T) {
 
 	size, byteSize := queue.QueueSize()
 	assert.Equal(t, 0, size)
-	assert.Equal(t, 0, byteSize)
+	assert.Equal(t, ByteCount(0), byteSize)
 
 	n := 100
 

--- a/connect/transfer_route_manager.go
+++ b/connect/transfer_route_manager.go
@@ -495,36 +495,14 @@ func (self *MultiRouteSelector) GetActiveRoutes() []Route {
         }
     }
 
-    mathrand.Shuffle(len(activeRoutes), func(i int, j int) {
-        activeRoutes[i], activeRoutes[j] = activeRoutes[j], activeRoutes[i]
-    })
-
     if self.weightedRoutes {
         // prioritize the routes (weighted shuffle)
         // if all weights are equal, this is the same as a shuffle
-        n := len(activeRoutes)
-        for i := 0; i < n - 1; i += 1 {
-            j := func ()(int) {
-                var net float32
-                net = 0
-                for j := i; j < n; j += 1 {
-                    net += self.routeWeight[activeRoutes[j]]
-                }
-                r := mathrand.Float32()
-                rnet := r * net
-                net = 0
-                for j := i; j < n; j += 1 {
-                    net += self.routeWeight[activeRoutes[j]]
-                    if rnet < net {
-                        return j
-                    }
-                }
-                panic("Incorrect weights")
-            }()
-            t := activeRoutes[i]
-            activeRoutes[i] = activeRoutes[j]
-            activeRoutes[j] = t
-        }
+        WeightedShuffle(activeRoutes, self.routeWeight)
+    } else {
+        mathrand.Shuffle(len(activeRoutes), func(i int, j int) {
+            activeRoutes[i], activeRoutes[j] = activeRoutes[j], activeRoutes[i]
+        })
     }
 
     return activeRoutes

--- a/connect/transfer_route_manager.go
+++ b/connect/transfer_route_manager.go
@@ -844,6 +844,53 @@ func (self *sendGatewayTransport) Downgrade(sourceId Id) {
 
 
 // conforms to `Transport`
+type sendClientTransport struct {
+    transportId Id
+    destinationIds map[Id]bool
+}
+
+func NewSendClientTransport(destinationIds ...Id) *sendClientTransport {
+    destinationIds_ := map[Id]bool{}
+    for _, destinationId := range destinationIds {
+        destinationIds_[destinationId] = true
+    }
+    return &sendClientTransport{
+        transportId: NewId(),
+        destinationIds: destinationIds_,
+    }
+}
+
+func (self *sendClientTransport) TransportId() Id {
+    return self.transportId
+}
+
+func (self *sendClientTransport) Priority() int {
+    return 100
+}
+
+func (self *sendClientTransport) CanEvalRouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) bool {
+    return true
+}
+
+func (self *sendClientTransport) RouteWeight(stats *RouteStats, remainingStats map[Transport]*RouteStats) float32 {
+    // uniform weight
+    return 1.0 / float32(1 + len(remainingStats))
+}
+
+func (self *sendClientTransport) MatchesSend(destinationId Id) bool {
+    return self.destinationIds[destinationId]
+}
+
+func (self *sendClientTransport) MatchesReceive(destinationId Id) bool {
+    return false
+}
+
+func (self *sendClientTransport) Downgrade(sourceId Id) {
+    // nothing to downgrade
+}
+
+
+// conforms to `Transport`
 type receiveGatewayTransport struct {
 	transportId Id
 }

--- a/connect/transfer_route_manager.go
+++ b/connect/transfer_route_manager.go
@@ -62,17 +62,15 @@ type MultiRouteReader interface {
 
 type RouteManager struct {
 	ctx context.Context
-    client *Client
 
     mutex sync.Mutex
     writerMatchState *MatchState
     readerMatchState *MatchState
 }
 
-func NewRouteManager(ctx context.Context, client *Client) *RouteManager {
+func NewRouteManager(ctx context.Context) *RouteManager {
     return &RouteManager{
     	ctx: ctx,
-        client: client,
         writerMatchState: NewMatchState(ctx, true, Transport.MatchesSend),
         // `weightedRoutes=false` because unless there is a cpu limit this is not needed
         readerMatchState: NewMatchState(ctx, false, Transport.MatchesReceive),

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -68,7 +68,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	// aContractManager := NewContractManagerWithDefaults(a)
 	defer a.Cancel()
 	// a.Setup(aRouteManager, aContractManager)
-	go a.Run()
+	// go a.Run()
 
 	aRouteManager.UpdateTransport(aSendTransport, []Route{aSend})
 	aRouteManager.UpdateTransport(aReceiveTransport, []Route{aReceive})
@@ -83,7 +83,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	// bContractManager := NewContractManagerWithDefaults(b)
 	defer b.Cancel()
 	// b.Setup(bRouteManager, bContractManager)
-	go b.Run()
+	// go b.Run()
 
 	bRouteManager.UpdateTransport(bSendTransport, []Route{bSend})
 	bRouteManager.UpdateTransport(bReceiveTransport, []Route{bReceive})
@@ -181,7 +181,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	// a2ContractManager := NewContractManagerWithDefaults(a2)
 	// a2.Setup(a2RouteManager, a2ContractManager)
 	defer a2.Cancel()
-	go a2.Run()
+	// go a2.Run()
 
 	a2RouteManager.UpdateTransport(aSendTransport, []Route{aSend})
 	a2RouteManager.UpdateTransport(aReceiveTransport, []Route{aReceive})
@@ -462,6 +462,9 @@ func (self *conditioner) run(in chan []byte, out chan []byte) {
 	}
 }
 
+
+
+// FIXME TestAckTimeout
 
 
 

--- a/connect/tun.go
+++ b/connect/tun.go
@@ -1,6 +1,0 @@
-package connect
-
-
-
-
-

--- a/connect/tun.go
+++ b/connect/tun.go
@@ -1,0 +1,6 @@
+package connect
+
+
+
+
+

--- a/connect/util.go
+++ b/connect/util.go
@@ -268,10 +268,9 @@ func WeightedShuffleWithEntropy[T comparable](values []T, weights map[T]float32,
             }
             r := mathrand.Float32()
             rnet := r * net
-            e := entropy * net
-            net = 0
+            net = entropy * net
             for j := i; j < n; j += 1 {
-                net += weights[values[j]] + e
+                net += weights[values[j]]
                 if rnet < net {
                     return j
                 }

--- a/connect/util.go
+++ b/connect/util.go
@@ -238,8 +238,6 @@ func (self *Event) SetOnSignals(signalValues ...syscall.Signal) func() {
 }
 
 
-// FIXME test this. run N times and look at the average position.
-// FIXME the average position order should equal the weight order
 func WeightedShuffle[T comparable](values []T, weights map[T]float32) {
 	mathrand.Shuffle(len(values), func(i int, j int) {
         values[i], values[j] = values[j], values[i]
@@ -282,5 +280,3 @@ func HandleError(do func(), handlers ...func()) {
     }()
     do()
 }
-
-

--- a/connect/util.go
+++ b/connect/util.go
@@ -10,6 +10,7 @@ import (
     "syscall"
     "fmt"
     "runtime/debug"
+    // "reflect"
     mathrand "math/rand"
 )
 
@@ -42,12 +43,17 @@ func (self *Monitor) NotifyAll() {
 // makes a copy of the list on update
 type CallbackList[T any] struct {
 	mutex sync.Mutex
+	// `callbacks` and `callbackIds` are parallel arrays
 	callbacks []T
+	callbackIds []int
+	nextCallbackId int
 }
 
 func NewCallbackList[T any]() *CallbackList[T] {
 	return &CallbackList[T]{
 		callbacks: []T{},
+		callbackIds: []int{},
+		nextCallbackId: 0,
 	}
 }
 
@@ -57,36 +63,41 @@ func (self *CallbackList[T]) Get() []T {
 	return self.callbacks
 }
 
-func (self *CallbackList[T]) Add(callback T) {
+func (self *CallbackList[T]) Add(callback T) int {
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 
-	i := slices.IndexFunc(self.callbacks, func(c T)(bool) {
-		return &c == &callback
-	})
-	if 0 <= i {
-		// already present
-		return
-	}
+	callbackId := self.nextCallbackId
+	self.nextCallbackId += 1
+
 	nextCallbacks := slices.Clone(self.callbacks)
 	nextCallbacks = append(nextCallbacks, callback)
 	self.callbacks = nextCallbacks
+	
+	nextCallbackIds := slices.Clone(self.callbackIds)
+	nextCallbackIds = append(nextCallbackIds, callbackId)
+	self.callbackIds = nextCallbackIds
+
+	return callbackId
 }
 
-func  (self *CallbackList[T]) Remove(callback T) {
+func  (self *CallbackList[T]) Remove(callbackId int) {
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 
-	i := slices.IndexFunc(self.callbacks, func(c T)(bool) {
-		return &c == &callback
-	})
-	if i < 0 {
+	i, found := slices.BinarySearch(self.callbackIds, callbackId)
+	if !found {
 		// not present
 		return
 	}
+
 	nextCallbacks := slices.Clone(self.callbacks)
-	nextCallbacks = slices.Delete(nextCallbacks, i, i)
+	nextCallbacks = slices.Delete(nextCallbacks, i, i + 1)
 	self.callbacks = nextCallbacks
+
+	nextCallbackIds := slices.Clone(self.callbackIds)
+	nextCallbackIds = slices.Delete(nextCallbackIds, i, i + 1)
+	self.callbackIds = nextCallbackIds
 }
 
 
@@ -239,6 +250,10 @@ func (self *Event) SetOnSignals(signalValues ...syscall.Signal) func() {
 
 
 func WeightedShuffle[T comparable](values []T, weights map[T]float32) {
+	WeightedShuffleWithEntropy[T](values, weights, 0)
+}
+
+func WeightedShuffleWithEntropy[T comparable](values []T, weights map[T]float32, entropy float32) {
 	mathrand.Shuffle(len(values), func(i int, j int) {
         values[i], values[j] = values[j], values[i]
     })
@@ -253,9 +268,10 @@ func WeightedShuffle[T comparable](values []T, weights map[T]float32) {
             }
             r := mathrand.Float32()
             rnet := r * net
+            e := entropy * net
             net = 0
             for j := i; j < n; j += 1 {
-                net += weights[values[j]]
+                net += weights[values[j]] + e
                 if rnet < net {
                     return j
                 }

--- a/connect/util.go
+++ b/connect/util.go
@@ -238,6 +238,8 @@ func (self *Event) SetOnSignals(signalValues ...syscall.Signal) func() {
 }
 
 
+// FIXME test this. run N times and look at the average position.
+// FIXME the average position order should equal the weight order
 func WeightedShuffle[T comparable](values []T, weights map[T]float32) {
 	mathrand.Shuffle(len(values), func(i int, j int) {
         values[i], values[j] = values[j], values[i]
@@ -260,13 +262,12 @@ func WeightedShuffle[T comparable](values []T, weights map[T]float32) {
                     return j
                 }
             }
-            // addition err, use the last value
+            // zero weights, use the last value
             return n - 1
         }()
         values[i], values[j] = values[j], values[i]
     }
 }
-
 
 
 func HandleError(do func(), handlers ...func()) {

--- a/connect/util.go
+++ b/connect/util.go
@@ -235,3 +235,33 @@ func (self *Event) SetOnSignals(signalValues ...syscall.Signal) func() {
 }
 
 
+func WeightedShuffle[T any](values []T, weights map[T]float32) {
+	mathrand.Shuffle(len(values), func(i int, j int) {
+        values[i], values[j] = values[j], values[i]
+    })
+
+    n := len(values)
+    for i := 0; i < n - 1; i += 1 {
+        j := func ()(int) {
+            var net float32
+            net = 0
+            for j := i; j < n; j += 1 {
+                net += weights[values[j]]
+            }
+            r := mathrand.Float32()
+            rnet := r * net
+            net = 0
+            for j := i; j < n; j += 1 {
+                net += weights[values[j]]
+                if rnet < net {
+                    return j
+                }
+            }
+            // addition err, use the last value
+            return n - 1
+        }()
+        values[i], values[j] = values[j], values[i]
+    }
+}
+
+

--- a/connect/util.go
+++ b/connect/util.go
@@ -8,6 +8,9 @@ import (
     "os"
     "os/signal"
     "syscall"
+    "fmt"
+    "runtime/debug"
+    mathrand "math/rand"
 )
 
 
@@ -235,7 +238,7 @@ func (self *Event) SetOnSignals(signalValues ...syscall.Signal) func() {
 }
 
 
-func WeightedShuffle[T any](values []T, weights map[T]float32) {
+func WeightedShuffle[T comparable](values []T, weights map[T]float32) {
 	mathrand.Shuffle(len(values), func(i int, j int) {
         values[i], values[j] = values[j], values[i]
     })
@@ -262,6 +265,21 @@ func WeightedShuffle[T any](values []T, weights map[T]float32) {
         }()
         values[i], values[j] = values[j], values[i]
     }
+}
+
+
+
+func HandleError(do func(), handlers ...func()) {
+    defer func() {
+        if r := recover(); r != nil {
+        	debug.PrintStack()
+            fmt.Printf("Unexpected error: %v\n", r)
+            for _, handler := range handlers {
+                handler()
+            }
+        }
+    }()
+    do()
 }
 
 

--- a/connect/util_test.go
+++ b/connect/util_test.go
@@ -1,0 +1,1 @@
+package connect

--- a/connect/util_test.go
+++ b/connect/util_test.go
@@ -10,6 +10,30 @@ import (
 )
 
 
+// FIXME
+// func TestMonitor() {
+
+// }
+
+
+// FIXME
+// func TestCallbackList() {
+
+// }
+
+
+// FIXME
+// func TestIdleCondition() {
+
+// }
+
+
+// FIXME
+// func TestEvent() {
+
+// }
+
+
 func TestWeightedShuffle(t *testing.T) {
 	// weighted shuffle many times and look at the average position
 	// the average position order should trend with the weight order

--- a/connect/util_test.go
+++ b/connect/util_test.go
@@ -1,1 +1,59 @@
 package connect
+
+import (
+    "testing"
+    "slices"
+    // "math"
+    // "fmt"
+
+    "github.com/go-playground/assert/v2"
+)
+
+
+func TestWeightedShuffle(t *testing.T) {
+	// weighted shuffle many times and look at the average position
+	// the average position order should trend with the weight order
+	
+	k := 64
+	n := 256
+
+	netIndexes := map[int]int64{}
+
+	for i := 0; i < n * k; i += 1 {
+		values := []int{}
+		weights := map[int]float32{}
+		for j := 0; j < n; j += 1 {
+			values = append(values, j)
+			weights[j] = float32(n - j)
+		}
+
+		WeightedShuffle(values, weights)
+		for index, value := range values {
+			netIndexes[value] += int64(index)
+		}
+	}
+
+	values := []int{}
+	for i := 0; i < n; i += 1 {
+		values = append(values, i)
+	}
+	slices.SortFunc(values, func(a int, b int)(int) {
+		if netIndexes[a] < netIndexes[b] {
+			return -1
+		} else if netIndexes[b] < netIndexes[a] {
+			return 1
+		} else {
+			return 0
+		}
+	})
+
+	errorThreshold := 2 * n / k
+	for i := 0; i < n; i += 1 {
+		e := i - values[i]
+		if -errorThreshold <= e && e <= errorThreshold {
+			e = 0
+		}
+		assert.Equal(t, 0, e)
+	}
+}
+

--- a/connectctl/go.mod
+++ b/connectctl/go.mod
@@ -7,10 +7,13 @@ replace bringyour.com/connect v0.0.0 => ../connect
 replace bringyour.com/protocol v0.0.0 => ../protocol/build/bringyour.com/protocol
 
 require (
-	bringyour.com/connect v0.0.0 // indirect
-	bringyour.com/protocol v0.0.0 // indirect
-	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 // indirect
-	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
+	bringyour.com/connect v0.0.0
+	bringyour.com/protocol v0.0.0
+	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
+	github.com/golang-jwt/jwt/v5 v5.2.0
+)
+
+require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/oklog/ulid/v2 v2.1.0 // indirect

--- a/connectctl/go.sum
+++ b/connectctl/go.sum
@@ -1,9 +1,13 @@
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
-github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=

--- a/connectctl/main.go
+++ b/connectctl/main.go
@@ -531,17 +531,17 @@ func send(opts docopt.Opts) {
     defer client.Close()
 
 
-    client.SetInstanceId(instanceId)
+    // client.SetInstanceId(instanceId)
     
 
-    routeManager := connect.NewRouteManager(client)
-    contractManager := connect.NewContractManagerWithDefaults(client)
-    client.Setup(routeManager, contractManager)
-    go client.Run()
+    // routeManager := connect.NewRouteManager(client)
+    // contractManager := connect.NewContractManagerWithDefaults(client)
+    // client.Setup(routeManager, contractManager)
+    // go client.Run()
 
     auth := &connect.ClientAuth{
         ByJwt: jwt,
-        InstanceId: client.InstanceId(),
+        InstanceId: instanceId,
         AppVersion: fmt.Sprintf("connectctl %s", ConnectCtlVersion),
     }
     for i := 0; i < transportCount; i += 1 {
@@ -549,16 +549,17 @@ func send(opts docopt.Opts) {
             cancelCtx,
             fmt.Sprintf("%s/", connectUrl),
             auth,
+            client.RouteManager(),
         )
         defer platformTransport.Close()
-        go platformTransport.Run(routeManager)
+        // go platformTransport.Run(routeManager)
     }
 
 
     provideModes := map[protocol.ProvideMode]bool{
         protocol.ProvideMode_Network: true,
     }
-    contractManager.SetProvideModes(provideModes)
+    client.ContractManager().SetProvideModes(provideModes)
 
 
     // FIXME break into 2k chunks?
@@ -664,24 +665,24 @@ func sink(opts docopt.Opts) {
     )
     defer client.Close()
 
-    client.SetInstanceId(instanceId)
+    // client.SetInstanceId(instanceId)
 
-    routeManager := connect.NewRouteManager(client)
-    contractManager := connect.NewContractManagerWithDefaults(client)
+    // routeManager := connect.NewRouteManager(client)
+    // contractManager := connect.NewContractManagerWithDefaults(client)
 
-    client.Setup(routeManager, contractManager)
-    go client.Run()
+    // client.Setup(routeManager, contractManager)
+    // go client.Run()
 
 
     provideModes := map[protocol.ProvideMode]bool{
         protocol.ProvideMode_Network: true,
     }
-    contractManager.SetProvideModes(provideModes)
+    client.ContractManager().SetProvideModes(provideModes)
 
 
     auth := &connect.ClientAuth{
         ByJwt: jwt,
-        InstanceId: client.InstanceId(),
+        InstanceId: instanceId,
         AppVersion: fmt.Sprintf("connectctl %s", ConnectCtlVersion),
     }
     for i := 0; i < transportCount; i += 1 {
@@ -689,9 +690,10 @@ func sink(opts docopt.Opts) {
             cancelCtx,
             fmt.Sprintf("%s/", connectUrl),
             auth,
+            client.RouteManager(),
         )
         defer platformTransport.Close()
-        go platformTransport.Run(routeManager)
+        // go platformTransport.Run(routeManager)
     }
 
     type Receive struct {

--- a/provider/main.go
+++ b/provider/main.go
@@ -118,19 +118,19 @@ func provide(opts docopt.Opts) {
     // routeManager := connect.NewRouteManager(connectClient)
     // contractManager := connect.NewContractManagerWithDefaults(connectClient)
     // connectClient.Setup(routeManager, contractManager)
-    go connectClient.Run()
+    // go connectClient.Run()
 
     fmt.Printf("client_id: %s\n", clientId)
     fmt.Printf("instance_id: %s\n", instanceId)
 
     auth := &connect.ClientAuth{
         ByJwt: byClientJwt,
-        ClientId: clientId,
+        // ClientId: clientId,
         InstanceId: instanceId,
         AppVersion: RequireVersion(),
     }
-    platformTransport := connect.NewPlatformTransportWithDefaults(ctx, connectUrl, auth)
-    go platformTransport.Run(connectClient.RouteManager())
+    connect.NewPlatformTransportWithDefaults(ctx, connectUrl, auth, connectClient.RouteManager())
+    // go platformTransport.Run(connectClient.RouteManager())
 
     localUserNat := connect.NewLocalUserNatWithDefaults(ctx)
     remoteUserNatProvider := connect.NewRemoteUserNatProvider(connectClient, localUserNat)

--- a/provider/main.go
+++ b/provider/main.go
@@ -115,18 +115,22 @@ func provide(opts docopt.Opts) {
 
     connectClient := connect.NewClientWithDefaults(ctx, clientId)
 
-    routeManager := connect.NewRouteManager(connectClient)
-    contractManager := connect.NewContractManagerWithDefaults(connectClient)
-    connectClient.Setup(routeManager, contractManager)
+    // routeManager := connect.NewRouteManager(connectClient)
+    // contractManager := connect.NewContractManagerWithDefaults(connectClient)
+    // connectClient.Setup(routeManager, contractManager)
     go connectClient.Run()
+
+    fmt.Printf("client_id: %s\n", clientId)
+    fmt.Printf("instance_id: %s\n", instanceId)
 
     auth := &connect.ClientAuth{
         ByJwt: byClientJwt,
+        ClientId: clientId,
         InstanceId: instanceId,
         AppVersion: RequireVersion(),
     }
     platformTransport := connect.NewPlatformTransportWithDefaults(ctx, connectUrl, auth)
-    go platformTransport.Run(routeManager)
+    go platformTransport.Run(connectClient.RouteManager())
 
     localUserNat := connect.NewLocalUserNatWithDefaults(ctx)
     remoteUserNatProvider := connect.NewRemoteUserNatProvider(connectClient, localUserNat)
@@ -135,7 +139,7 @@ func provide(opts docopt.Opts) {
         protocol.ProvideMode_Public: true,
         protocol.ProvideMode_Network: true,
     }
-    contractManager.SetProvideModes(provideModes)
+    connectClient.ContractManager().SetProvideModes(provideModes)
 
 
     fmt.Printf(
@@ -186,6 +190,7 @@ func provideAuth(ctx context.Context, apiUrl string, opts docopt.Opts) (byClient
             panic(err)
         }
         password = string(passwordBytes)
+        fmt.Printf("\n")
     }
 
     // fmt.Printf("userAuth='%s'; password='%s'\n", userAuth, password)


### PR DESCRIPTION
This PR includes a number of fixes to the `connect` lib, additional tests, and adds a new `UserNatClient` implementation called `RemoteUserNatMultiClient`. This implements a window of clients and selects the best client ranked by passive statistics and availability, with some random easing. The algorithm is described at a high level at [1].

1. https://bringyour.com/blog/visual/

