### PR TITLE
Add blackhole detection to the multi client

### DIFF
--- a/connect/ip_remote_multi_client_test.go
+++ b/connect/ip_remote_multi_client_test.go
@@ -170,7 +170,8 @@ func TestMultiClientChannelWindowStats(t *testing.T) {
 	// ensure that the bucket counts are bounded
 	// if this is broken, the coalesce logic is broken and there will be a memory issue
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	timeout := 10 * time.Second
 


### PR DESCRIPTION
This is an issue if provider contract settings are mismatched with the sender. Idle timeout will currently not catch this case.