### PR TITLE
multi fixes

### DIFF
--- a/connect/ip_remote_multi_client.go
+++ b/connect/ip_remote_multi_client.go
@@ -78,6 +78,7 @@ func DefaultMultiClientSettings() *MultiClientSettings {
 		StatsWindowBucketDuration:    10 * time.Second,
 		StatsSampleWeightsCount:      8,
 		StatsSourceCountSelection:    0.95,
+		ClientAffinityTimeout:        0 * time.Second,
 
 		RemoteUserNatMultiClientMonitorSettings: *DefaultRemoteUserNatMultiClientMonitorSettings(),
 	}
@@ -114,6 +115,10 @@ type MultiClientSettings struct {
 	StatsWindowBucketDuration    time.Duration
 	StatsSampleWeightsCount      int
 	StatsSourceCountSelection    float64
+	// lower affinity is more private
+	// however, there may be some applications that assume the same ip across multiple connections
+	// in those cases, we would need some small affinity
+	ClientAffinityTimeout time.Duration
 
 	RemoteUserNatMultiClientMonitorSettings
 }
@@ -130,6 +135,11 @@ type RemoteUserNatMultiClient struct {
 
 	window *multiClientWindow
 
+	securityPolicy *SecurityPolicy
+	// the provide mode of the source packets
+	// for locally generated packets this is `ProvideMode_Network`
+	provideMode protocol.ProvideMode
+
 	stateLock      sync.Mutex
 	ip4PathUpdates map[Ip4Path]*multiClientChannelUpdate
 	ip6PathUpdates map[Ip6Path]*multiClientChannelUpdate
@@ -142,11 +152,13 @@ func NewRemoteUserNatMultiClientWithDefaults(
 	ctx context.Context,
 	generator MultiClientGenerator,
 	receivePacketCallback ReceivePacketFunction,
+	provideMode protocol.ProvideMode,
 ) *RemoteUserNatMultiClient {
 	return NewRemoteUserNatMultiClient(
 		ctx,
 		generator,
 		receivePacketCallback,
+		provideMode,
 		DefaultMultiClientSettings(),
 	)
 }
@@ -155,6 +167,7 @@ func NewRemoteUserNatMultiClient(
 	ctx context.Context,
 	generator MultiClientGenerator,
 	receivePacketCallback ReceivePacketFunction,
+	provideMode protocol.ProvideMode,
 	settings *MultiClientSettings,
 ) *RemoteUserNatMultiClient {
 	cancelCtx, cancel := context.WithCancel(ctx)
@@ -174,6 +187,8 @@ func NewRemoteUserNatMultiClient(
 		receivePacketCallback: receivePacketCallback,
 		settings:              settings,
 		window:                window,
+		securityPolicy:        DefaultSecurityPolicy(),
+		provideMode:           provideMode,
 		ip4PathUpdates:        map[Ip4Path]*multiClientChannelUpdate{},
 		ip6PathUpdates:        map[Ip6Path]*multiClientChannelUpdate{},
 		updateIp4Paths:        map[*multiClientChannelUpdate]map[Ip4Path]bool{},
@@ -322,14 +337,41 @@ func (self *RemoteUserNatMultiClient) SendPacket(
 	provideMode protocol.ProvideMode,
 	packet []byte,
 	timeout time.Duration,
-) (success bool) {
-	parsedPacket, err := newParsedPacket(packet)
+) bool {
+	minRelationship := max(provideMode, self.provideMode)
+
+	ipPath, r, err := self.securityPolicy.Inspect(minRelationship, packet)
 	if err != nil {
-		// bad packet
 		glog.Infof("[multi]send bad packet = %s\n", err)
-		success = false
-		return
+		return false
 	}
+	switch r {
+	case SecurityPolicyResultAllow:
+		parsedPacket := &parsedPacket{
+			ipPath: ipPath,
+			packet: packet,
+		}
+		return self.sendPacket(source, provideMode, parsedPacket, timeout)
+	default:
+		// TODO upgrade port 53 and port 80 here with protocol specific conversions
+		glog.Infof("[multi]drop packet -> %d %v %s:%d\n", ipPath.Version, ipPath.Protocol, ipPath.DestinationIp, ipPath.DestinationPort)
+		return false
+	}
+}
+
+func (self *RemoteUserNatMultiClient) sendPacket(
+	source TransferPath,
+	provideMode protocol.ProvideMode,
+	parsedPacket *parsedPacket,
+	timeout time.Duration,
+) (success bool) {
+	// parsedPacket, err := newParsedPacket(packet)
+	// if err != nil {
+	// 	// bad packet
+	// 	glog.Infof("[multi]send bad packet = %s\n", err)
+	// 	success = false
+	// 	return
+	// }
 
 	self.updateClientPath(parsedPacket.ipPath, func(update *multiClientChannelUpdate) {
 		enterTime := time.Now()
@@ -340,6 +382,7 @@ func (self *RemoteUserNatMultiClient) SendPacket(
 			if err == nil {
 				return
 			}
+			update.client.ClearAffinity()
 			glog.Infof("[multi]send error = %s\n", err)
 			// find a new client
 			update.client = nil
@@ -353,16 +396,63 @@ func (self *RemoteUserNatMultiClient) SendPacket(
 				self.removeClient(client)
 			}
 
+			// in order, try
+			// - the temporal affinity
+			//   connections initiated near each other in time will use the same client
+			// - clients in order
+
+			if 0 < self.settings.ClientAffinityTimeout {
+				// this implementation is a best-effort at affinity
+				// it will not ensure affinity between parallel sends in all cases
+				var mostRecentAffinityClient *multiClientChannel
+				for _, client := range orderedClients {
+					affinityCount, affinityTime := client.MostRecentAffinity()
+					if 0 < affinityCount && enterTime.Sub(affinityTime) < self.settings.ClientAffinityTimeout {
+						if mostRecentAffinityClient == nil {
+							mostRecentAffinityClient = client
+						} else if _, mostRecentAffinityTime := mostRecentAffinityClient.MostRecentAffinity(); mostRecentAffinityTime.Before(affinityTime) {
+							mostRecentAffinityClient = client
+						}
+					}
+				}
+				if mostRecentAffinityClient != nil {
+					affinityTimeout := min(self.settings.WriteRetryTimeout, self.settings.ClientAffinityTimeout)
+					if 0 <= timeout {
+						remainingTimeout := enterTime.Add(timeout).Sub(time.Now())
+
+						if remainingTimeout <= 0 {
+							// drop
+							success = false
+							return
+						}
+
+						affinityTimeout = min(affinityTimeout, remainingTimeout)
+					}
+					if mostRecentAffinityClient.Send(parsedPacket, affinityTimeout) {
+						glog.V(2).Infof("[multi]use affinity client ipv%d p%v -> %s:%d\n", parsedPacket.ipPath.Version, parsedPacket.ipPath.Protocol, parsedPacket.ipPath.DestinationIp, parsedPacket.ipPath.DestinationPort)
+						// lock the path to the client
+						mostRecentAffinityClient.UpdateAffinity( /*parsedPacket.ipPath*/ )
+						update.client = mostRecentAffinityClient
+						success = true
+						return
+					}
+					// else choose a new client
+				}
+				// else choose a new client
+			}
+
 			for _, client := range orderedClients {
 				if client.Send(parsedPacket, 0) {
+					glog.V(2).Infof("[multi]use new client ipv%d p%v -> %s:%d\n", parsedPacket.ipPath.Version, parsedPacket.ipPath.Protocol, parsedPacket.ipPath.DestinationIp, parsedPacket.ipPath.DestinationPort)
 					// lock the path to the client
+					client.UpdateAffinity( /*parsedPacket.ipPath*/ )
 					update.client = client
 					success = true
 					return
 				}
 			}
 
-			var retryTimeout time.Duration
+			retryTimeout := self.settings.WriteRetryTimeout
 			if 0 <= timeout {
 				remainingTimeout := enterTime.Add(timeout).Sub(time.Now())
 
@@ -372,19 +462,18 @@ func (self *RemoteUserNatMultiClient) SendPacket(
 					return
 				}
 
-				retryTimeout = min(remainingTimeout, self.settings.WriteRetryTimeout)
-
-			} else {
-				retryTimeout = self.settings.WriteRetryTimeout
+				retryTimeout = min(retryTimeout, remainingTimeout)
 			}
 
 			if 0 < len(orderedClients) {
 				// distribute the timeout evenly via wait
 				retryTimeoutPerClient := retryTimeout / time.Duration(len(orderedClients))
 				for _, client := range orderedClients {
-					success, err = client.SendDetailed(parsedPacket, retryTimeoutPerClient)
+					success, err := client.SendDetailed(parsedPacket, retryTimeoutPerClient)
 					if success && err == nil {
 						// lock the path to the client
+						glog.V(2).Infof("[multi]wait for new client ipv%d p%v -> %s:%d\n", parsedPacket.ipPath.Version, parsedPacket.ipPath.Protocol, parsedPacket.ipPath.DestinationIp, parsedPacket.ipPath.DestinationPort)
+						client.UpdateAffinity( /*parsedPacket.ipPath*/ )
 						update.client = client
 						success = true
 						return
@@ -738,14 +827,13 @@ func (self *multiClientWindow) randomEnumerateClientArgs() {
 	visitedDestinations := map[MultiHopId]bool{}
 	for {
 		destinationEstimatedBytesPerSecond := map[MultiHopId]ByteCount{}
+		next := func(count int) (map[MultiHopId]ByteCount, error) {
+			return self.generator.NextDestinations(
+				count,
+				maps.Keys(visitedDestinations),
+			)
+		}
 		for {
-			next := func(count int) (map[MultiHopId]ByteCount, error) {
-				return self.generator.NextDestinations(
-					count,
-					maps.Keys(visitedDestinations),
-				)
-			}
-
 			nextDestinationEstimatedBytesPerSecond, err := next(1)
 			if err != nil {
 				select {
@@ -781,23 +869,33 @@ func (self *multiClientWindow) randomEnumerateClientArgs() {
 			}
 		}()
 
-		for destination, estimatedBytesPerSecond := range destinationEstimatedBytesPerSecond {
-			if clientArgs, err := self.generator.NewClientArgs(); err == nil {
-				args := &multiClientChannelArgs{
-					Destination:                    destination,
-					EstimatedBytesPerSecond:        estimatedBytesPerSecond,
-					MultiClientGeneratorClientArgs: *clientArgs,
+		if 0 < len(destinationEstimatedBytesPerSecond) {
+			for destination, estimatedBytesPerSecond := range destinationEstimatedBytesPerSecond {
+				if clientArgs, err := self.generator.NewClientArgs(); err == nil {
+					args := &multiClientChannelArgs{
+						Destination:                    destination,
+						EstimatedBytesPerSecond:        estimatedBytesPerSecond,
+						MultiClientGeneratorClientArgs: *clientArgs,
+					}
+					select {
+					case <-self.ctx.Done():
+						self.generator.RemoveClientArgs(clientArgs)
+						return
+					case self.clientChannelArgs <- args:
+					}
+				} else {
+					glog.Infof("[multi]create client args error = %s\n", err)
 				}
-				select {
-				case <-self.ctx.Done():
-					self.generator.RemoveClientArgs(clientArgs)
-					return
-				case self.clientChannelArgs <- args:
-				}
-			} else {
-				glog.Infof("[multi]create client args error = %s\n", err)
-			}
 
+			}
+		} else {
+			// this case happens when find providers is not correctly excluding clients
+			select {
+			case <-self.ctx.Done():
+				return
+			case <-time.After(self.settings.WindowEnumerateEmptyTimeout):
+				glog.V(2).Infof("[multi]window enumerate empty timeout (api mismatch).\n")
+			}
 		}
 	}
 }
@@ -1283,6 +1381,9 @@ type multiClientChannel struct {
 	packetStats               *clientWindowStats
 	endErr                    error
 
+	affinityCount int
+	affinityTime  time.Time
+
 	clientReceiveUnsub func()
 }
 
@@ -1332,6 +1433,8 @@ func newMultiClientChannel(
 		ip6DestinationSourceCount: map[Ip6Path]map[Ip6Path]int{},
 		packetStats:               &clientWindowStats{},
 		endErr:                    nil,
+		affinityCount:             0,
+		affinityTime:              time.Time{},
 	}
 	go HandleError(clientChannel.detectBlackhole, cancel)
 
@@ -1347,6 +1450,29 @@ func (self *multiClientChannel) ClientId() Id {
 
 func (self *multiClientChannel) IsP2pOnly() bool {
 	return self.args.MultiClientGeneratorClientArgs.P2pOnly
+}
+
+func (self *multiClientChannel) UpdateAffinity() {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.affinityCount += 1
+	self.affinityTime = time.Now()
+}
+
+func (self *multiClientChannel) ClearAffinity() {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.affinityCount = 0
+	self.affinityTime = time.Time{}
+}
+
+func (self *multiClientChannel) MostRecentAffinity() (int, time.Time) {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	return self.affinityCount, self.affinityTime
 }
 
 func (self *multiClientChannel) Send(parsedPacket *parsedPacket, timeout time.Duration) bool {

--- a/connect/net_http_doh.go
+++ b/connect/net_http_doh.go
@@ -26,13 +26,15 @@ func DefaultDohSettings() *DohSettings {
 // see:
 // https://developers.cloudflare.com/1.1.1.1/ip-addresses/
 // https://www.quad9.net/
-
+// https://support.opendns.com/hc/en-us/articles/360038086532-Using-DNS-over-HTTPS-DoH-with-OpenDNS
 func dohUrlsIpv4() []string {
 	return []string{
 		"https://1.1.1.1/dns-query",
 		"https://1.0.0.1/dns-query",
 		"https://9.9.9.9:5053/dns-query",
 		"https://149.112.112.112:5053/dns-query",
+		"https://208.67.222.222/dns-query",
+		"https://208.67.220.220/dns-query",
 	}
 }
 
@@ -42,6 +44,8 @@ func dohUrlsIpv6() []string {
 		"https://[2606:4700:4700::1001]/dns-query",
 		"https://[2620:fe::fe]:5053/dns-query",
 		"https://[2620:fe::9]:5053/dns-query",
+		"https://[2620:119:35::35]/dns-query",
+		"https://[2620:119:53::53]/dns-query",
 	}
 }
 


### PR DESCRIPTION
Address issues with the client. There are several important changes:

- 53 and 80 are unblocked temporarily. I think it's correct to let the device make the ultimate choice of protocol. However, in many cases it does make sense to explore an inline upgrade strategy.
- security rules added to the multi client
- enumeration and client selection edge cases addressed in the multi client
