### PR TITLE
hold destructive verdicts when the evidence is about the shared path

### DIFF
--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -341,6 +341,10 @@ func DefaultMultiClientSettings() *MultiClientSettings {
 		// any evidence of life, so the cost of warning a provider that was
 		// merely asleep is a few minutes out of new-flow selection
 		ProbeSilenceWarnStreak: 2,
+		// three exits going silent inside ten seconds is not three provider
+		// deaths; see the field comment
+		SharedFateMinExits: 3,
+		SharedFateWindow:   10 * time.Second,
 		// mainnet-aggressive: evaluate twice the candidates a window expansion
 		// needs and keep the best. 1 is today's behavior, the A/B point.
 		EvaluationPoolMultiple: 2,
@@ -854,6 +858,21 @@ type MultiClientSettings struct {
 	//
 	// 0 is off (the pre-change behavior and the A/B comparison point).
 	ProbeSilenceWarnStreak int
+
+	// SharedFateMinExits and SharedFateWindow are the shared-fate verdict
+	// gate: when at least SharedFateMinExits DISTINCT exits develop
+	// silence/stall evidence inside one SharedFateWindow, the common cause is
+	// overwhelmingly the shared path (the phone's access network wobbling,
+	// bufferbloat, a handoff), not that many independent providers died in
+	// the same seconds -- so DESTRUCTIVE verdicts hold while the correlation
+	// stands. Benching (non-destructive) continues, receive progress still
+	// acquits, and a genuinely dead exit still executes the first pass after
+	// the correlation clears. The field captures that motivate it: mainnet
+	// congestion waves benching 6 exits at once (2026-08-04), and a stable
+	// pool where every stall conviction clustered with siblings' silence
+	// (2026-08-05). SharedFateMinExits 0 or SharedFateWindow 0 is off.
+	SharedFateMinExits int
+	SharedFateWindow   time.Duration
 
 	// EvaluationPoolMultiple is the aggressive-pooling knob: window expansion
 	// requests and ping-evaluates this multiple of the candidates it actually
@@ -2058,6 +2077,8 @@ type ReliabilitySettings struct {
 	ProbeTimeout               time.Duration
 	ProbeSampleHostCount       int
 	ProbeSilenceWarnStreak     int
+	SharedFateMinExits         int
+	SharedFateWindow           time.Duration
 	EvaluationPoolMultiple     int
 	// FormationPollTimeout: 0 falls back to SendRetryTimeout (the pre-change
 	// behavior), unlike the other zero-value-off knobs here
@@ -2112,6 +2133,8 @@ func ReliabilitySettingsFrom(settings *MultiClientSettings) *ReliabilitySettings
 		ProbeTimeout:               settings.ProbeTimeout,
 		ProbeSampleHostCount:       settings.ProbeSampleHostCount,
 		ProbeSilenceWarnStreak:     settings.ProbeSilenceWarnStreak,
+		SharedFateMinExits:         settings.SharedFateMinExits,
+		SharedFateWindow:           settings.SharedFateWindow,
 		EvaluationPoolMultiple:     settings.EvaluationPoolMultiple,
 		FormationPollTimeout:       settings.FormationPollTimeout,
 
@@ -3662,7 +3685,23 @@ func (self *RemoteUserNatMultiClient) rebindCandidates(dying *multiClientChannel
 			gather(window.unorderedClients())
 		}
 	}
+	// a candidate that has never delivered a byte sorts LAST, whatever its
+	// event recency: a fresh dial to a qualified destination reads as proven
+	// (qualification is destination-keyed) while its own transport is
+	// unproven, and the field capture that motivates this (2026-08-05)
+	// showed a dead-on-arrival replacement inherit 24 flows and execute 90s
+	// later -- one teardown amplified into two. Proven candidates take the
+	// flows while they have headroom; the unproven tier still exists so an
+	// all-fresh pool can place flows at all.
 	slices.SortStableFunc(candidates, func(a *multiClientChannel, b *multiClientChannel) int {
+		provenA := a.hasEverReceived()
+		provenB := b.hasEverReceived()
+		if provenA != provenB {
+			if provenA {
+				return -1
+			}
+			return 1
+		}
 		// descending: most recently active first
 		timeA := lastEventTimes[a]
 		timeB := lastEventTimes[b]
@@ -6819,6 +6858,21 @@ func (self *multiClientWindow) convictSendStalls(stallTimeout time.Duration) boo
 		return false
 	}
 
+	// every stalled exit is CURRENT evidence for the shared-fate window,
+	// recorded for ALL of them before ANY is judged -- recording inside the
+	// judgment loop would let the first-judged exit convict before its
+	// co-sufferers were visible
+	reliabilitySettings = self.reliabilitySettings()
+	sharedFateOn := reliabilitySettings != nil &&
+		0 < reliabilitySettings.SharedFateMinExits &&
+		0 < reliabilitySettings.SharedFateWindow
+	if sharedFateOn {
+		now := time.Now()
+		for _, client := range stalled {
+			client.metrics().recordSharedFate(client.ClientId(), now)
+		}
+	}
+
 	convicted := false
 	for i, client := range stalled {
 		verdict := verdicts[i]
@@ -6841,6 +6895,30 @@ func (self *multiClientWindow) convictSendStalls(stallTimeout time.Duration) boo
 				"detail", verdict.detail,
 				"bar", stallTimeout,
 			))
+			continue
+		}
+		if client.isQuarantined() {
+			// held: the bench already owns this exit's lifecycle. New flows
+			// are stopped, the movable flows were handed off at bench time,
+			// and the quarantine acquits on receive progress or executes on
+			// sustained silence -- a second judge executing mid-bench
+			// destroys exactly the flows the bench is protecting. The field
+			// capture that motivates this (2026-08-05, stable providers):
+			// every stall conviction in the window landed 6-41s after a
+			// bench, ahead of the acquittal that receive-silence benches on
+			// that pool overwhelmingly earn. The stall clock is deliberately
+			// NOT refreshed, so a real stall still convicts on carried
+			// evidence the first pass after the bench lifts.
+			client.resetBusyProbeSendFailures()
+			if client.markStallHoldOnce() {
+				loggerOrDefault(self.log).Infof("%s\n", relEvent(
+					"busy_probe",
+					"exit", client.ClientId(),
+					"outcome", "held",
+					"detail", "benched: quarantine owns the verdict",
+					"bar", stallTimeout,
+				))
+			}
 			continue
 		}
 		if !receivingElsewhere(client) {
@@ -6872,6 +6950,29 @@ func (self *multiClientWindow) convictSendStalls(stallTimeout time.Duration) boo
 				))
 			}
 			continue
+		}
+		if sharedFateOn {
+			peers := client.metrics().sharedFatePeers(client.ClientId(), time.Now(), reliabilitySettings.SharedFateWindow)
+			if reliabilitySettings.SharedFateMinExits <= peers+1 {
+				// held: this many exits stalling in the same seconds is one
+				// fact about the shared path, not peers+1 facts about
+				// providers. The stall clock is NOT refreshed -- the first
+				// pass after the correlation clears convicts a real stall on
+				// carried evidence.
+				client.resetBusyProbeSendFailures()
+				if client.markStallHoldOnce() {
+					client.metrics().verdictHeldSharedFate()
+					loggerOrDefault(self.log).Infof("%s\n", relEvent(
+						"busy_probe",
+						"exit", client.ClientId(),
+						"outcome", "held",
+						"detail", "shared fate",
+						"peers", peers,
+						"bar", stallTimeout,
+					))
+				}
+				continue
+			}
 		}
 		reason := fmt.Sprintf("no ack progress for %s", stallTimeout)
 		if verdict.detail != "" {
@@ -9724,6 +9825,17 @@ func (self *multiClientChannel) busyProbeOutstandingNow() bool {
 // (packetStats counts send acks but does not stamp them), and inventing a
 // second age from a field that does not exist is how a diagnostic ends up
 // reporting a number nobody produced.
+// hasEverReceived reports whether this channel has ever delivered return
+// traffic. Provider qualification is DESTINATION-keyed and survives channel
+// incarnations, so a fresh dial to a qualified destination reads as proven
+// while its own transport has delivered nothing -- this is the channel-level
+// proof-of-delivery those consumers gate on.
+func (self *multiClientChannel) hasEverReceived() bool {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+	return !self.lastReceiveAckTime.IsZero()
+}
+
 func (self *multiClientChannel) probeReceiveAge() int64 {
 	self.stateLock.Lock()
 	defer self.stateLock.Unlock()
@@ -10174,6 +10286,19 @@ func (self *multiClientChannel) affinityDonorEligible(followQuarantine bool, win
 	}
 	if self.quarantined {
 		if !followQuarantine || window <= 0 {
+			return donorQuarantineScattered
+		}
+		if self.lastReceiveAckTime.IsZero() {
+			// following a BENCHED donor is a bet that the bench is a false
+			// positive -- reasonable for an exit that has been delivering
+			// and went briefly silent, and indefensible for one that has
+			// never delivered anything at all. The 2026-08-05 capture is the
+			// latter: a dead-on-arrival replacement (send 0/0B recv 0/0B)
+			// grew from 20 to 32 flows by group-follow while already
+			// benched, then executed and took them all down. An exit that
+			// has never received scatters instead; a fresh exit that has not
+			// been benched is unaffected, since normal inheritance never
+			// reaches this branch.
 			return donorQuarantineScattered
 		}
 		if self.quarantineStart.IsZero() || window <= time.Since(self.quarantineStart) {
@@ -10963,6 +11088,7 @@ func (self *multiClientChannel) detectBlackhole() {
 	// suppress", and one suppressed verdict re-evaluated every 1.25s for a
 	// minute is still one suppressed verdict.
 	heldCounted := false
+	sharedFateCounted := false
 
 	for {
 		if windowStats, err := self.WindowStats(); err != nil {
@@ -11043,6 +11169,16 @@ func (self *multiClientChannel) detectBlackhole() {
 				},
 			)
 			blackhole := reason != blackholeNone
+
+			// admissible receive-silence is CURRENT evidence for the
+			// shared-fate window, recorded before any gate so concurrent
+			// sufferers see each other
+			sharedFateMinExits := self.reliabilitySettings().SharedFateMinExits
+			sharedFateWindow := self.reliabilitySettings().SharedFateWindow
+			sharedFateOn := 0 < sharedFateMinExits && 0 < sharedFateWindow
+			if blackhole && sharedFateOn {
+				self.metrics().recordSharedFate(self.ClientId(), now)
+			}
 
 			if held != blackholeNone {
 				if !heldCounted {
@@ -11154,31 +11290,61 @@ func (self *multiClientChannel) detectBlackhole() {
 					// from an immediate one. The "Blackhole " prefix is shared
 					// by both forms on purpose: the window's storm breaker
 					// keys verdict-driven removals on it.
-					expired := ""
-					if action == verdictActionExecuteExpired {
-						expired = " quarantine expired"
+					sharedFateHeld := false
+					if sharedFateOn {
+						peers := self.metrics().sharedFatePeers(self.ClientId(), now, sharedFateWindow)
+						if sharedFateMinExits <= peers+1 {
+							// held: this many exits silent in the same seconds
+							// is one fact about the shared path. No addError --
+							// endErr is first-write-wins and there is no
+							// un-conviction. The loop keeps judging (falling
+							// through to the pass wait, never skipping it):
+							// receive progress acquits, and a genuinely dead
+							// exit executes the first pass after the
+							// correlation clears, on its own carried evidence.
+							sharedFateHeld = true
+							if !sharedFateCounted {
+								sharedFateCounted = true
+								self.metrics().verdictHeldSharedFate()
+								self.log.Infof("%s\n", relEvent(
+									"verdict_hold",
+									"exit", self.ClientId(),
+									"reason", string(reason),
+									"cause", "shared_fate",
+									"peers", peers,
+									"flows", flowCount,
+								))
+							}
+						}
 					}
-					// dsts is the distinct-send-destination count behind the
-					// MinBlackholeDestinations gate: a field capture must be
-					// able to tell "many destinations silent" (a real
-					// blackhole) from "one destination silent" (a dead
-					// website that squeaked past a lowered gate) on the one
-					// line that survives into a field log.
-					self.addError(fmt.Errorf(
-						"Blackhole %s%s (send %d/%dB recv %d/%dB syn %d/%d nackAge %s synAge %s dsts=%d)",
-						reason,
-						expired,
-						windowStats.sendAckCount,
-						windowStats.sendAckByteCount,
-						windowStats.receiveAckCount,
-						windowStats.receiveAckByteCount,
-						windowStats.sendSynCount,
-						windowStats.receiveSynCount,
-						blackholeAgeString(windowStats.firstSendNackTime),
-						blackholeAgeString(windowStats.firstSendSynTime),
-						windowStats.sendDestinationCount,
-					))
-					return
+					if !sharedFateHeld {
+						sharedFateCounted = false
+						expired := ""
+						if action == verdictActionExecuteExpired {
+							expired = " quarantine expired"
+						}
+						// dsts is the distinct-send-destination count behind the
+						// MinBlackholeDestinations gate: a field capture must be
+						// able to tell "many destinations silent" (a real
+						// blackhole) from "one destination silent" (a dead
+						// website that squeaked past a lowered gate) on the one
+						// line that survives into a field log.
+						self.addError(fmt.Errorf(
+							"Blackhole %s%s (send %d/%dB recv %d/%dB syn %d/%d nackAge %s synAge %s dsts=%d)",
+							reason,
+							expired,
+							windowStats.sendAckCount,
+							windowStats.sendAckByteCount,
+							windowStats.receiveAckCount,
+							windowStats.receiveAckByteCount,
+							windowStats.sendSynCount,
+							windowStats.receiveSynCount,
+							blackholeAgeString(windowStats.firstSendNackTime),
+							blackholeAgeString(windowStats.firstSendSynTime),
+							windowStats.sendDestinationCount,
+						))
+						return
+					}
 				}
 			} else {
 				// the bench-leak escape (see quarantineVacated): no verdict is

--- a/ip_remote_multi_client_bind_flow_test.go
+++ b/ip_remote_multi_client_bind_flow_test.go
@@ -325,8 +325,14 @@ func TestAffinityDonorEligibleVerdicts(t *testing.T) {
 	client.setWarning(false, warnNone)
 
 	// a FRESH quarantine episode follows: the exact state production creates
-	// (setQuarantined stamps quarantineStart = now), no hand-set receive
-	// evidence required -- this is what makes the mechanism reachable
+	// (setQuarantined stamps quarantineStart = now). The past receive is
+	// production state too, not evidence hand-set to reach the mechanism: an
+	// exit earns flows by delivering, so a benched one has always received
+	// at SOME point -- what it lacks is a RECENT receive, and requiring that
+	// is what made this branch unreachable before (review, 2026-08-03).
+	client.stateLock.Lock()
+	client.lastReceiveAckTime = time.Now().Add(-time.Hour)
+	client.stateLock.Unlock()
 	client.setQuarantined(blackholeNoReceiveAck)
 	if got := client.affinityDonorEligible(true, window); got != donorQuarantineFollowed {
 		t.Errorf("fresh quarantine: verdict %v, want donorQuarantineFollowed", got)
@@ -347,6 +353,23 @@ func TestAffinityDonorEligibleVerdicts(t *testing.T) {
 	if got := client.affinityDonorEligible(true, window); got != donorQuarantineScattered {
 		t.Errorf("aged quarantine: verdict %v, want donorQuarantineScattered", got)
 	}
+
+	// a benched donor that has NEVER delivered a byte scatters: following it
+	// is a bet that the bench is a false positive, which is indefensible for
+	// a transport that has proven nothing. The 2026-08-05 capture: a
+	// dead-on-arrival replacement (send 0/0B recv 0/0B) grew 20 -> 32 flows
+	// by follow while benched, then executed and took them all down.
+	client.clearQuarantine()
+	client.stateLock.Lock()
+	client.lastReceiveAckTime = time.Time{}
+	client.stateLock.Unlock()
+	client.setQuarantined(blackholeNoReceiveAck)
+	if got := client.affinityDonorEligible(true, window); got != donorQuarantineScattered {
+		t.Errorf("never-received benched donor: verdict %v, want donorQuarantineScattered", got)
+	}
+	client.stateLock.Lock()
+	client.lastReceiveAckTime = time.Now().Add(-time.Hour)
+	client.stateLock.Unlock()
 
 	// warning wins over quarantine: an unhealthy benched exit never donates
 	client.clearQuarantine()
@@ -386,6 +409,7 @@ func TestQuarantinedDonorKeepsItsSite(t *testing.T) {
 
 	// production state, nothing hand-set: a fresh episode is inside the
 	// follow window by construction
+	stampDonorReceived(donor)
 	donor.setQuarantined(blackholeNoReceiveAck)
 
 	newFlow := &multiClientChannelUpdate{}
@@ -451,6 +475,7 @@ func TestPinnedFlowFollowsBenchWithoutWindow(t *testing.T) {
 	donorPaths := map[Ip4Path]time.Time{ip4: time.Now()}
 
 	// a bench well past the 45s follow window
+	stampDonorReceived(donor)
 	donor.setQuarantined(blackholeNoReceiveAck)
 	donor.stateLock.Lock()
 	donor.quarantineStart = time.Now().Add(-2 * parent.settings.GroupFollowWindow)
@@ -795,4 +820,13 @@ func TestAffinityNameCollapsesCdnConstellations(t *testing.T) {
 			t.Errorf("alias %q -> %q chains: %q is itself aliased", from, to, to)
 		}
 	}
+}
+
+// stampDonorReceived puts a donor in the state production always has by the
+// time it can be benched: it has delivered before (that is how it earned its
+// flows), just not recently. See affinityDonorEligible.
+func stampDonorReceived(client *multiClientChannel) {
+	client.stateLock.Lock()
+	defer client.stateLock.Unlock()
+	client.lastReceiveAckTime = time.Now().Add(-time.Hour)
 }

--- a/ip_remote_multi_client_observability.go
+++ b/ip_remote_multi_client_observability.go
@@ -492,6 +492,7 @@ type heartbeatState struct {
 	rebindsRedialed uint64
 	probesSent      uint64
 	probesAnswered  uint64
+	heldSharedFate  uint64
 	removals        uint64
 	groupsFollowed  uint64
 	groupsScattered uint64
@@ -559,6 +560,7 @@ func heartbeatStateFrom(exits []*ExitInfo, metrics *ReliabilityMetricsSnapshot, 
 		state.rebindsRedialed = metrics.RebindsRedialed
 		state.probesSent = metrics.ProbesSent
 		state.probesAnswered = metrics.ProbesAnswered
+		state.heldSharedFate = metrics.VerdictsHeldSharedFate
 		state.removals = metrics.ExitLossEvents
 		state.groupsFollowed = metrics.GroupsFollowed
 		state.groupsScattered = metrics.GroupsScattered
@@ -583,6 +585,10 @@ func relHeartbeatLine(state heartbeatState, uptime time.Duration) string {
 		"flows", state.flows,
 		"tiers", pair(state.tierMin, state.tierMax),
 		"held", pair(state.heldUplink, state.heldTransport),
+		// destructive verdicts held because enough exits went silent inside
+		// one shared-fate window that the shared path is the likely cause; a
+		// rising count during a wave is the detector doing its job
+		"fate", state.heldSharedFate,
 		"deferred", state.deferred,
 		"rebinds", pair(state.rebindsAccepted, state.rebindsRedialed),
 		"probes", pair(state.probesSent, state.probesAnswered),

--- a/ip_remote_multi_client_observability_test.go
+++ b/ip_remote_multi_client_observability_test.go
@@ -376,7 +376,7 @@ func TestHeartbeatContentFromFixture(t *testing.T) {
 
 	line := relHeartbeatLine(state, 125*time.Second)
 	want := "[rel] event=heartbeat exits=3 proven=2 quarantined=1 warned=2 flows=6 " +
-		"tiers=0/3 held=7/2 deferred=1 rebinds=9/3 probes=40/38 follow=6/1 pins=2/1 removals=5 uptime=125"
+		"tiers=0/3 held=7/2 fate=0 deferred=1 rebinds=9/3 probes=40/38 follow=6/1 pins=2/1 removals=5 uptime=125"
 	AssertEqual(t, line, want)
 }
 
@@ -445,6 +445,7 @@ func TestHeartbeatSignatureSuppression(t *testing.T) {
 		"probesSent":  func(s *heartbeatState) { s.probesSent += 1 },
 		"answered":    func(s *heartbeatState) { s.probesAnswered += 1 },
 		"removals":    func(s *heartbeatState) { s.removals += 1 },
+		"fate":        func(s *heartbeatState) { s.heldSharedFate += 1 },
 	} {
 		changed := first
 		mutate(&changed)

--- a/ip_remote_multi_client_shared_fate_test.go
+++ b/ip_remote_multi_client_shared_fate_test.go
@@ -1,0 +1,285 @@
+package connect
+
+// Tests for the 2026-08-05 betanet fixes: the shared-fate verdict gate, the
+// stall hold while quarantined, and the proof-of-delivery gates on flow
+// inheritance.
+//
+// The field capture that motivates all three (stable providers): every stall
+// conviction in the window landed 6-41s after a receive-silence bench,
+// executing the flows the bench was protecting; the flows then re-raced onto
+// a fresh dial that had never delivered a byte (destination-keyed
+// qualification made it read as proven), which executed 90s later with 32
+// flows -- one hiccup amplified into two. The phone's uplink blipped 42 times
+// in 2.4h: correlated silence across exits is one fact about the shared path.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- the shared-fate recorder ---
+
+func TestSharedFateRecorder(t *testing.T) {
+	m := newReliabilityMetrics()
+	now := time.Now()
+	window := 10 * time.Second
+
+	a, b, c := NewId(), NewId(), NewId()
+
+	// empty: no peers
+	AssertEqual(t, m.sharedFatePeers(a, now, window), 0)
+
+	// self-evidence is not a peer
+	m.recordSharedFate(a, now)
+	AssertEqual(t, m.sharedFatePeers(a, now, window), 0)
+
+	// two distinct others are two peers; re-recording deduplicates
+	m.recordSharedFate(b, now)
+	m.recordSharedFate(b, now)
+	m.recordSharedFate(c, now)
+	AssertEqual(t, m.sharedFatePeers(a, now, window), 2)
+
+	// evidence outside the window is pruned, and re-recording refreshes
+	m.recordSharedFate(b, now.Add(-2*window))
+	AssertEqual(t, m.sharedFatePeers(a, now, window), 1)
+	m.recordSharedFate(b, now)
+	AssertEqual(t, m.sharedFatePeers(a, now, window), 2)
+
+	// zero window is off, and a nil receiver is inert
+	AssertEqual(t, m.sharedFatePeers(a, now, 0), 0)
+	var nilMetrics *reliabilityMetrics
+	nilMetrics.recordSharedFate(a, now)
+	AssertEqual(t, nilMetrics.sharedFatePeers(a, now, window), 0)
+}
+
+// identify gives a bare fixture channel its own client id: ClientId() falls
+// back to the args id, and two fixtures sharing the zero id collapse into one
+// entry everywhere identity is the key (the shared-fate map, the candidate
+// gather) -- which silently un-tests exactly what these tests assert.
+func identify(client *multiClientChannel) *multiClientChannel {
+	client.args = &multiClientChannelArgs{
+		MultiClientGeneratorClientArgs: MultiClientGeneratorClientArgs{ClientId: NewId()},
+	}
+	return client
+}
+
+// --- fix 1: the stall hold while quarantined ---
+
+// A benched exit's lifecycle belongs to the quarantine: acquittal on receive
+// progress or execution on sustained silence. The busy-probe stall path must
+// hold rather than execute mid-bench -- and the stall clock is deliberately
+// not refreshed, so once the bench lifts a real stall convicts on carried
+// evidence.
+func TestStallConvictionHeldWhileQuarantined(t *testing.T) {
+	stallTimeout := 20 * time.Millisecond
+
+	client := busyProbeTestChannel(t, func(timeout time.Duration, ackCallback func(error)) (bool, error) {
+		// queued, never answered: the conviction state
+		return true, nil
+	})
+	stallPast(client, stallTimeout)
+
+	sibling := receivingSibling()
+	window := busyProbeTestWindow(40*time.Millisecond, client, sibling)
+
+	AssertEqual(t, client.setQuarantined(blackholeNoReceiveAck), true)
+	AssertEqual(t, window.convictSendStalls(stallTimeout), false)
+	AssertEqual(t, client.IsDone(), false)
+	client.stateLock.Lock()
+	endErr := client.endErr
+	client.stateLock.Unlock()
+	AssertEqual(t, endErr == nil, true)
+
+	// the bench lifts with the stall still real: the carried evidence
+	// convicts once the probe budget of a fresh pass elapses
+	client.clearQuarantine()
+	AssertEqual(t, convictWithin(window, sibling, stallTimeout, 2*time.Second), true)
+	AssertEqual(t, client.IsDone(), true)
+}
+
+// convictWithin re-runs the stall pass until it convicts or the deadline
+// passes, re-freshening the sibling's receive stamp per attempt: the
+// corroboration window is stallTimeout+budget (tens of ms here), so a
+// sibling stamped once at fixture construction goes stale mid-loop and the
+// pass holds on "uplink unproven" instead of exercising the path under test.
+func convictWithin(window *multiClientWindow, sibling *multiClientChannel, stallTimeout time.Duration, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		sibling.stateLock.Lock()
+		sibling.lastReceiveAckTime = time.Now()
+		sibling.stateLock.Unlock()
+		if window.convictSendStalls(stallTimeout) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// --- fix 3: the shared-fate gate on the stall path ---
+
+func TestStallConvictionHeldOnSharedFate(t *testing.T) {
+	stallTimeout := 20 * time.Millisecond
+
+	metrics := newReliabilityMetrics()
+	client := busyProbeTestChannel(t, func(timeout time.Duration, ackCallback func(error)) (bool, error) {
+		return true, nil
+	})
+	client.reliabilityMetricsFunc = func() *reliabilityMetrics { return metrics }
+	stallPast(client, stallTimeout)
+
+	sibling := receivingSibling()
+	window := busyProbeTestWindow(40*time.Millisecond, client, sibling)
+	window.reliabilitySettingsFunc = func() *ReliabilitySettings {
+		return &ReliabilitySettings{
+			BusyProbe:          true,
+			BusyProbeBudget:    40 * time.Millisecond,
+			SharedFateMinExits: 2,
+			SharedFateWindow:   time.Minute,
+		}
+	}
+
+	// another exit developed silence evidence moments ago: two exits inside
+	// one window is the shared-path signature at MinExits=2
+	metrics.recordSharedFate(NewId(), time.Now())
+
+	AssertEqual(t, window.convictSendStalls(stallTimeout), false)
+	AssertEqual(t, client.IsDone(), false)
+	AssertEqual(t, metrics.verdictsHeldSharedFate.Load() >= 1, true)
+
+	// the correlation clears (the peer's evidence ages out): the carried
+	// stall evidence convicts on the next pass
+	metrics.sharedFateLock.Lock()
+	for id := range metrics.sharedFateEvidences {
+		if id != client.ClientId() {
+			metrics.sharedFateEvidences[id] = time.Now().Add(-2 * time.Minute)
+		}
+	}
+	metrics.sharedFateLock.Unlock()
+
+	AssertEqual(t, convictWithin(window, sibling, stallTimeout, 2*time.Second), true)
+	AssertEqual(t, client.IsDone(), true)
+}
+
+// The stall pass itself records evidence: two exits stalling in the same
+// pass see each other and both hold, even though neither was recorded before
+// the pass began.
+func TestStallPassCrossRecordsSharedFate(t *testing.T) {
+	stallTimeout := 20 * time.Millisecond
+
+	metrics := newReliabilityMetrics()
+	newStalled := func() *multiClientChannel {
+		c := busyProbeTestChannel(t, func(timeout time.Duration, ackCallback func(error)) (bool, error) {
+			return true, nil
+		})
+		c.reliabilityMetricsFunc = func() *reliabilityMetrics { return metrics }
+		return c
+	}
+	clientA := identify(newStalled())
+	clientB := identify(newStalled())
+	// both must be past the bar: the pass judges only clients sendStalled
+	// reports, and the point of the test is that TWO of them see each other
+	clientA.addSend(1440, udpTestPath(4))
+	clientB.addSend(1440, udpTestPath(4))
+	time.Sleep(stallTimeout + 30*time.Millisecond)
+	AssertEqual(t, clientA.sendStalled(stallTimeout), true)
+	AssertEqual(t, clientB.sendStalled(stallTimeout), true)
+
+	window := busyProbeTestWindow(40*time.Millisecond, clientA, clientB, receivingSibling())
+	window.reliabilitySettingsFunc = func() *ReliabilitySettings {
+		return &ReliabilitySettings{
+			BusyProbe:          true,
+			BusyProbeBudget:    40 * time.Millisecond,
+			SharedFateMinExits: 2,
+			SharedFateWindow:   time.Minute,
+		}
+	}
+
+	window.convictSendStalls(stallTimeout)
+	// neither co-sufferer is executed: each saw the other's evidence,
+	// recorded by the same pass that judged them
+	AssertEqual(t, clientA.IsDone(), false)
+	AssertEqual(t, clientB.IsDone(), false)
+	AssertEqual(t, 2 <= metrics.verdictsHeldSharedFate.Load(), true)
+}
+
+// --- fix 3: the shared-fate gate at the blackhole verdict site ---
+
+// The wiring anchor, in the house style: the gate must sit in detectBlackhole
+// between the verdict decision and addError -- endErr is first-write-wins, so
+// a hold that runs after addError holds nothing -- and it must FALL THROUGH
+// to the pass wait rather than continue, or a held exit spins the verdict
+// loop hot.
+func TestBlackholeSharedFateGateCallSites(t *testing.T) {
+	source, err := readSource("ip_remote_multi_client.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, ok := functionBody(source, "func (self *multiClientChannel) detectBlackhole(")
+	if !ok {
+		t.Fatal("could not find detectBlackhole")
+	}
+	record := indexOfOrFatal(t, body, "self.metrics().recordSharedFate(")
+	gate := indexOfOrFatal(t, body, "self.metrics().sharedFatePeers(")
+	execute := indexOfOrFatal(t, body, `self.addError(fmt.Errorf(`)
+	if !(record < gate && gate < execute) {
+		t.Error("the shared-fate record and gate must precede the blackhole execution: record, then gate, then addError")
+	}
+	if heldVar := indexOfOrFatal(t, body, "sharedFateHeld := false"); !(heldVar < execute) {
+		t.Error("the hold must be expressed as a fall-through guard around the execution, not a continue past the pass wait")
+	}
+}
+
+func indexOfOrFatal(t *testing.T, body string, needle string) int {
+	t.Helper()
+	i := strings.Index(body, needle)
+	if i < 0 {
+		t.Fatalf("%q not found", needle)
+	}
+	return i
+}
+
+// --- fix 2: proof of delivery before flow inheritance ---
+
+// A candidate that has never delivered a byte sorts behind every proven
+// candidate, whatever its event recency: destination-keyed qualification
+// makes a fresh dial read as proven while its transport is unproven.
+func TestRebindCandidatesUnprovenSortLast(t *testing.T) {
+	parent := bindFlowTestParent()
+	proven := identify(bindFlowTestChannel(parent))
+	unproven := identify(bindFlowTestChannel(parent))
+	proven.log = NewNoopLogger()
+	unproven.log = NewNoopLogger()
+	proven.packetStats = &clientWindowStats{log: NewNoopLogger()}
+	unproven.packetStats = &clientWindowStats{log: NewNoopLogger()}
+
+	// the proven candidate delivered long ago; the unproven one is newer by
+	// event recency and must still sort last
+	proven.stateLock.Lock()
+	proven.lastReceiveAckTime = time.Now().Add(-time.Minute)
+	proven.stateLock.Unlock()
+	unproven.stateLock.Lock()
+	unproven.packetStats.lastEventTime = time.Now()
+	unproven.stateLock.Unlock()
+
+	// the candidate gather is exercised directly: the window offer plumbing
+	// is not what this test is about
+	parent.rebindCandidatesFunc = nil
+	window := &multiClientWindow{
+		ctx:  context.Background(),
+		log:  NewNoopLogger(),
+		settings: parent.settings,
+		clients: map[Id]*multiClientChannel{
+			proven.ClientId():   proven,
+			unproven.ClientId(): unproven,
+		},
+	}
+	parent.windows = map[WindowType]*multiClientWindow{WindowTypeQuality: window}
+
+	candidates := parent.rebindCandidates(nil)
+	AssertEqual(t, len(candidates), 2)
+	AssertEqual(t, candidates[0] == proven, true)
+	AssertEqual(t, candidates[1] == unproven, true)
+}

--- a/reliability_metrics.go
+++ b/reliability_metrics.go
@@ -132,6 +132,11 @@ type reliabilityMetrics struct {
 	// the verdict-gating work that increments them lands separately, and
 	// defining the counters first means that work ships already measured.
 	verdictsHeldUplinkStale   atomic.Uint64
+	// verdictsHeldSharedFate counts destructive verdicts held because enough
+	// DISTINCT exits developed silence/stall evidence inside one short window
+	// that the common cause is overwhelmingly the shared path (the phone's
+	// access network), not that many independent providers died at once.
+	verdictsHeldSharedFate atomic.Uint64
 	verdictsHeldTransportDown atomic.Uint64
 	removalsDeferred          atomic.Uint64
 
@@ -147,6 +152,13 @@ type reliabilityMetrics struct {
 	// rate for tuning; nothing attributes it.
 	probesSent         atomic.Uint64
 	probesAnswered     atomic.Uint64
+
+	// the shared-fate evidence ring: which exits have CURRENT silence/stall
+	// evidence, deduplicated by exit and pruned to the configured window on
+	// access. Written on verdict passes (a few suspicious exits at a time),
+	// never on a packet path.
+	sharedFateLock      sync.Mutex
+	sharedFateEvidences map[Id]time.Time
 	providersQualified atomic.Uint64
 
 	// the busy-flow liveness probe (see busyLivenessProbe). busyProbesSent
@@ -207,6 +219,49 @@ func (self *reliabilityMetrics) flowReraced() {
 		return
 	}
 	self.flowsReraced.Add(1)
+}
+
+// recordSharedFate stamps CURRENT silence/stall evidence against an exit.
+// Re-recording refreshes the stamp: the question the window answers is "how
+// many exits look silent right now", not "how many ever did".
+func (self *reliabilityMetrics) recordSharedFate(exitId Id, now time.Time) {
+	if self == nil {
+		return
+	}
+	self.sharedFateLock.Lock()
+	defer self.sharedFateLock.Unlock()
+	if self.sharedFateEvidences == nil {
+		self.sharedFateEvidences = map[Id]time.Time{}
+	}
+	self.sharedFateEvidences[exitId] = now
+}
+
+// sharedFatePeers counts DISTINCT exits other than exitId with evidence
+// inside the window, pruning stale entries as it goes.
+func (self *reliabilityMetrics) sharedFatePeers(exitId Id, now time.Time, window time.Duration) int {
+	if self == nil || window <= 0 {
+		return 0
+	}
+	self.sharedFateLock.Lock()
+	defer self.sharedFateLock.Unlock()
+	peers := 0
+	for id, at := range self.sharedFateEvidences {
+		if window <= now.Sub(at) {
+			delete(self.sharedFateEvidences, id)
+			continue
+		}
+		if id != exitId {
+			peers += 1
+		}
+	}
+	return peers
+}
+
+func (self *reliabilityMetrics) verdictHeldSharedFate() {
+	if self == nil {
+		return
+	}
+	self.verdictsHeldSharedFate.Add(1)
 }
 
 func (self *reliabilityMetrics) verdictHeldUplinkStale() {
@@ -477,6 +532,7 @@ func (self *reliabilityMetrics) reset() {
 	self.rebindsAccepted.Store(0)
 	self.rebindsRedialed.Store(0)
 	self.verdictsHeldUplinkStale.Store(0)
+	self.verdictsHeldSharedFate.Store(0)
 	self.verdictsHeldTransportDown.Store(0)
 	self.removalsDeferred.Store(0)
 	self.probesSent.Store(0)
@@ -538,6 +594,7 @@ type ReliabilityMetricsSnapshot struct {
 	// uplink was stale, the transport was known down); RemovalsDeferred
 	// counts provider removals postponed while such a hold was in effect.
 	VerdictsHeldUplinkStale   uint64
+	VerdictsHeldSharedFate    uint64
 	VerdictsHeldTransportDown uint64
 	RemovalsDeferred          uint64
 
@@ -591,6 +648,7 @@ func (self *reliabilityMetrics) snapshot() *ReliabilityMetricsSnapshot {
 		RebindsRedialed: self.rebindsRedialed.Load(),
 
 		VerdictsHeldUplinkStale:   self.verdictsHeldUplinkStale.Load(),
+		VerdictsHeldSharedFate:    self.verdictsHeldSharedFate.Load(),
 		VerdictsHeldTransportDown: self.verdictsHeldTransportDown.Load(),
 		RemovalsDeferred:          self.removalsDeferred.Load(),
 


### PR DESCRIPTION
Three fixes for a failure mode that only became visible on a pool of *stable* providers. Stacks on #190 (branch is cut from it); the diff here is the three commits at the tip.

## What the field capture showed

A 14-hour session against known-good providers, with the client's own instrumentation: probe answer rate 94%, zero silent-provider warnings, removals averaging 0.18/min. The providers were fine. The hiccups were ours:

- **Every stall conviction in the window landed 6–41s after that same exit had been benched** for receive silence. The bench had already stopped new flows and handed off the movable ones and was waiting out its acquittal window — which receive-silence benches on that pool overwhelmingly earn. The busy-probe stall path convicted anyway, tearing down the 10–36 TCP flows the bench existed to protect. Two judges, no awareness of each other, ~130 flows lost in 90 minutes.
- **The teardown then amplified.** Flows re-raced onto a freshly dialed replacement whose first log line was its own quarantine: zero bytes sent, zero received, dead on arrival. It inherited flows anyway — provider qualification is destination-keyed, so a fresh dial to a qualified destination reads as proven while its own transport has proven nothing — and took 32 more flows down 90 seconds later.
- **The trigger was almost certainly the phone**: its uplink blipped stale→fresh 42 times in 2.4 hours (150–300ms each). A blip plus a little bufferbloat makes a healthy exit look receive-silent and send-stalled at once — and with 15 exits, the stall path's "some sibling is receiving" corroboration is trivially satisfied even when the shared path is the actual problem.

## The fixes

**1. A benched exit's lifecycle belongs to the bench.** The stall path holds instead of executing while a quarantine is active; the quarantine acquits on receive progress or executes on sustained silence, as it already did. The stall clock is deliberately not refreshed, so a genuinely stalled exit convicts on carried evidence the first pass after the bench lifts.

**2. Proof of delivery before flow inheritance.** Rebind candidates that have never received a byte sort behind every proven candidate (the tier still exists, so an all-fresh pool can still place flows), and a never-received exit cannot act as an affinity-group donor. Destination-keyed qualification stays as it is — this is a channel-level check that complements it.

**3. Shared-fate verdict holding** (`SharedFateMinExits`, default 3 / `SharedFateWindow`, default 10s; either 0 disables). When that many *distinct* exits develop silence or stall evidence inside one window, the common cause is overwhelmingly the shared path, not that many independent providers died in the same seconds — so **destructive** verdicts hold while the correlation stands. Benching continues (it is non-destructive and it is what protects the flows), receive progress still acquits, and a genuinely dead exit executes on the first pass after the correlation clears, on its own carried evidence. Both verdict sites are gated: the blackhole path and the stall path. Evidence is recorded for every stalled exit *before* any of them is judged, so co-sufferers can see each other within a single pass.

Observability: `event=verdict_hold cause=shared_fate peers=N`, `event=busy_probe outcome=held detail="benched: quarantine owns the verdict"`, a `fate=` key on the heartbeat, and a `VerdictsHeldSharedFate` metric.

## Notes

- All three are settings-gated and default-on with conservative values; `SharedFateMinExits: 0` restores the previous behavior exactly, which is the A/B comparison point.
- The shared-fate hold falls through to the verdict loop's pass wait rather than skipping it — a held exit must not spin the loop hot. There is a source anchor test for that, and for the gate sitting ahead of `addError` (which is first-write-wins: a hold that ran after it would hold nothing).
- Tests: a recorder unit test, behavior tests for both holds through the real stall pass, a cross-recording test proving two exits stalling in one pass see each other, the call-site anchor, and a candidate-ordering test. Full suite green in the sibling-workspace layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)