### PR TITLE
net: fail closed after indeterminate writes on the resilient TLS path

### DIFF
--- a/net_extender.go
+++ b/net_extender.go
@@ -188,7 +188,9 @@ func newExtenderDialTlsContext(
 					return nil, err
 				}
 				// once the stream is established, no longer need the resilient features
-				rconn.Off()
+				if err := rconn.Off(); err != nil {
+					return nil, err
+				}
 
 				serverConn = tlsServerConn
 			} else {

--- a/net_resilient.go
+++ b/net_resilient.go
@@ -13,6 +13,7 @@ import (
 	// "slices"
 
 	"crypto/tls"
+	"io"
 	// "crypto/ecdsa"
 	// "crypto/ed25519"
 	// "crypto/elliptic"
@@ -99,7 +100,10 @@ func newResilientDialTlsContext(
 			return nil, err
 		}
 		// once the stream is established, no longer need the resilient features
-		rconn.Off()
+		if err := rconn.Off(); err != nil {
+			tlsConn.Close()
+			return nil, err
+		}
 
 		return tlsConn, nil
 	}
@@ -130,13 +134,66 @@ func NewResilientTlsConn(conn net.Conn, fragment bool, reorder bool) *ResilientT
 	return resilientTlsConn
 }
 
-func (self *ResilientTlsConn) Off() {
+// Off permanently disables the resilient fragment/reorder layer. It drains
+// any partially-buffered record first — an earlier Write already returned
+// len(b), nil for those bytes, so stranding them would silently lose data
+// the caller believes was sent. A partial or failed drain leaves the wire
+// state indeterminate: the connection is failed closed (closed, so the
+// caller must not hand it back as established) and the drain error is
+// returned — io.ErrShortWrite when the drain came up short with a nil
+// error. Returns nil on a successful drain or when the buffer is empty.
+// Off is not safe for concurrent use with Write.
+func (self *ResilientTlsConn) Off() error {
+	if 0 < len(self.buffer) {
+		n, err := self.conn.Write(self.buffer)
+		if err != nil || n < len(self.buffer) {
+			if err == nil {
+				err = io.ErrShortWrite
+			}
+			self.failConnection()
+			return err
+		}
+		self.buffer = nil
+	}
 	// can't turn back on after off because we don't know where to align the tls header
 	self.enabled.Store(false)
+	return nil
 }
 
 func (self *ResilientTlsConn) Enabled() bool {
 	return self.enabled.Load()
+}
+
+// failConnection marks the connection unusable after an indeterminate write
+// (a partial or failed record send: the peer has part of the bytes and the
+// wire state is unknowable). The buffered record is dropped so it is never
+// re-sent, the resilient layer is disabled, and the underlying connection is
+// closed so later writes fail instead of appending to a corrupt stream.
+func (self *ResilientTlsConn) failConnection() {
+	self.buffer = nil
+	self.enabled.Store(false)
+	self.conn.Close()
+}
+
+// writeRecord writes record whole to w. On any short or failed write the
+// connection is failed closed: a partial record on the wire cannot be
+// coherently retried — the buffer still holds the full record, so a retry
+// would re-send the bytes already on the wire — and the layer is disabled
+// and the connection closed so later writes fail instead of appending to
+// the corrupt stream. A short write with a nil error is converted to
+// io.ErrShortWrite so the caller never mistakes a closed connection for
+// success. The buffer is not advanced here; callers advance it past the
+// record only after this returns nil.
+func (self *ResilientTlsConn) writeRecord(w io.Writer, record []byte) error {
+	n, err := w.Write(record)
+	if err == nil && n == len(record) {
+		return nil
+	}
+	if err == nil {
+		err = io.ErrShortWrite
+	}
+	self.failConnection()
+	return err
 }
 
 func (self *ResilientTlsConn) Write(b []byte) (int, error) {
@@ -158,10 +215,12 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 						splitRangeMid := (meta.ServerNameValueEnd + meta.ServerNameValueStart) / 2
 						splitRange := splitRangeMid - meta.ServerNameValueStart
 						stepRange := meta.ServerNameValueEnd - (meta.ServerNameValueStart + splitRange)
+
 						if splitRange <= 0 || stepRange <= 0 {
 							// the server name is too short to fragment;
 							// fall back to a single write
-							if _, err := self.conn.Write(tlsHeader.reconstruct(handshakeBytes)); err != nil {
+							record := tlsHeader.reconstruct(handshakeBytes)
+							if err := self.writeRecord(self.conn, record); err != nil {
 								return 0, err
 							}
 							self.buffer = self.buffer[5+tlsHeader.contentLength:]
@@ -187,17 +246,23 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 								if nativeTtl <= 0 {
 									// syscall failed or returned a value we can't safely restore
 									// (setting back to 0 would drop all packets at the first hop)
-									if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes)); err != nil {
+									record := tlsHeader.reconstruct(handshakeBytes)
+									if err := self.writeRecord(tcpConn, record); err != nil {
 										return 0, err
 									}
 									self.buffer = self.buffer[5+tlsHeader.contentLength:]
 									continue
 								}
+								// restore the TTL on every exit after this point,
+								// including fragment-write failures; defer LIFO
+								// runs it before f.Close() closes the dup'd fd
+								defer SetSocketTtl(fd, nativeTtl)
 
 								// fmt.Printf("native ttl=%d, server name start=%d, end=%d\n", nativeTtl, meta.ServerNameValueStart, meta.ServerNameValueEnd)
 
 								SetSocketTtl(fd, 0)
-								if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes[0:split])); err != nil {
+								record := tlsHeader.reconstruct(handshakeBytes[0:split])
+								if err := self.writeRecord(tcpConn, record); err != nil {
 									return 0, err
 								}
 								// fmt.Printf("frag ttl=0\n")
@@ -210,7 +275,8 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 										ttl = nativeTtl
 									}
 									SetSocketTtl(fd, ttl)
-									if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes[i:min(i+step, meta.ServerNameValueEnd)])); err != nil {
+									record := tlsHeader.reconstruct(handshakeBytes[i:min(i+step, meta.ServerNameValueEnd)])
+									if err := self.writeRecord(tcpConn, record); err != nil {
 										return 0, err
 									}
 									// fmt.Printf("frag ttl=%d\n", ttl)
@@ -218,23 +284,27 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 
 								SetSocketTtl(fd, nativeTtl)
 
-								if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes[meta.ServerNameValueEnd:])); err != nil {
+								tailRecord := tlsHeader.reconstruct(handshakeBytes[meta.ServerNameValueEnd:])
+								if err := self.writeRecord(tcpConn, tailRecord); err != nil {
 									return 0, err
 								}
 								// fmt.Printf("frag ttl=%d\n", nativeTtl)
 							} else if self.fragment {
 
-								if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes[0:split])); err != nil {
+								record := tlsHeader.reconstruct(handshakeBytes[0:split])
+								if err := self.writeRecord(tcpConn, record); err != nil {
 									return 0, err
 								}
 
 								for i := split; i < meta.ServerNameValueEnd; i += step {
-									if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes[i:min(i+step, meta.ServerNameValueEnd)])); err != nil {
+									record := tlsHeader.reconstruct(handshakeBytes[i:min(i+step, meta.ServerNameValueEnd)])
+									if err := self.writeRecord(tcpConn, record); err != nil {
 										return 0, err
 									}
 								}
 
-								if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes[meta.ServerNameValueEnd:])); err != nil {
+								record = tlsHeader.reconstruct(handshakeBytes[meta.ServerNameValueEnd:])
+								if err := self.writeRecord(tcpConn, record); err != nil {
 									return 0, err
 								}
 
@@ -254,12 +324,16 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 								nativeTtl := GetSocketTtl(fd)
 								if nativeTtl <= 0 {
 									// syscall failed; fall back to a single write
-									if _, err := tcpConn.Write(tlsBytes); err != nil {
+									if err := self.writeRecord(tcpConn, tlsBytes); err != nil {
 										return 0, err
 									}
 									self.buffer = self.buffer[5+tlsHeader.contentLength:]
 									continue
 								}
+								// restore the TTL on every exit after this point,
+								// including block-write failures; defer LIFO
+								// runs it before f.Close() closes the dup'd fd
+								defer SetSocketTtl(fd, nativeTtl)
 
 								for i := 0; i*blockSize < len(tlsBytes); i += 1 {
 									var ttl int
@@ -270,7 +344,7 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 									}
 									SetSocketTtl(fd, ttl)
 									b := tlsBytes[i*blockSize : min((i+1)*blockSize, len(tlsBytes))]
-									if _, err := tcpConn.Write(b); err != nil {
+									if err := self.writeRecord(tcpConn, b); err != nil {
 										return 0, err
 									}
 								}
@@ -278,7 +352,8 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 								SetSocketTtl(fd, nativeTtl)
 
 							} else {
-								if _, err := tcpConn.Write(tlsHeader.reconstruct(handshakeBytes)); err != nil {
+								record := tlsHeader.reconstruct(handshakeBytes)
+								if err := self.writeRecord(tcpConn, record); err != nil {
 									return 0, err
 								}
 							}
@@ -286,21 +361,25 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 						} else {
 
 							if self.fragment {
-								if _, err := self.conn.Write(tlsHeader.reconstruct(handshakeBytes[0:split])); err != nil {
+								record := tlsHeader.reconstruct(handshakeBytes[0:split])
+								if err := self.writeRecord(self.conn, record); err != nil {
 									return 0, err
 								}
 
 								for i := split; i < meta.ServerNameValueEnd; i += step {
-									if _, err := self.conn.Write(tlsHeader.reconstruct(handshakeBytes[i:min(i+step, meta.ServerNameValueEnd)])); err != nil {
+									record := tlsHeader.reconstruct(handshakeBytes[i:min(i+step, meta.ServerNameValueEnd)])
+									if err := self.writeRecord(self.conn, record); err != nil {
 										return 0, err
 									}
 								}
 
-								if _, err := self.conn.Write(tlsHeader.reconstruct(handshakeBytes[meta.ServerNameValueEnd:])); err != nil {
+								record = tlsHeader.reconstruct(handshakeBytes[meta.ServerNameValueEnd:])
+								if err := self.writeRecord(self.conn, record); err != nil {
 									return 0, err
 								}
 							} else {
-								if _, err := self.conn.Write(tlsHeader.reconstruct(handshakeBytes)); err != nil {
+								record := tlsHeader.reconstruct(handshakeBytes)
+								if err := self.writeRecord(self.conn, record); err != nil {
 									return 0, err
 								}
 							}
@@ -308,16 +387,16 @@ func (self *ResilientTlsConn) Write(b []byte) (int, error) {
 						}
 
 					} else {
-						// flush the raw record
-						_, err := self.conn.Write(self.buffer[0 : 5+tlsHeader.contentLength])
-						if err != nil {
+						// flush the raw record; a short or failed write leaves a
+						// partial record on the wire, so writeRecord fails closed
+						if err := self.writeRecord(self.conn, self.buffer[0:5+tlsHeader.contentLength]); err != nil {
 							return 0, err
 						}
 					}
 				} else {
-					// flush the raw record
-					_, err := self.conn.Write(self.buffer[0 : 5+tlsHeader.contentLength])
-					if err != nil {
+					// flush the raw record; a short or failed write leaves a
+					// partial record on the wire, so writeRecord fails closed
+					if err := self.writeRecord(self.conn, self.buffer[0:5+tlsHeader.contentLength]); err != nil {
 						return 0, err
 					}
 				}

--- a/net_resilient_fail_closed_linux_test.go
+++ b/net_resilient_fail_closed_linux_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package connect
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// countOpenFds counts the process's open file descriptors via /proc/self/fd,
+// which only exists on Linux.
+func countOpenFds(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("read /proc/self/fd: %v", err)
+	}
+	return len(entries)
+}
+
+// TestResilientTlsConnFragmentDoesNotLeakFileDescriptors verifies the
+// fragment+reorder path closes the dup'd socket fd on failure.
+func TestResilientTlsConnFragmentDoesNotLeakFileDescriptors(t *testing.T) {
+	record := buildClientHelloRecord(t)
+
+	before := countOpenFds(t)
+	for i := 0; i < 20; i++ {
+		client, server := newTcpPair(t)
+		client.SetWriteDeadline(time.Now().Add(-time.Second))
+		rconn := NewResilientTlsConn(client, true, true)
+		if _, err := rconn.Write(record); err == nil {
+			t.Fatalf("iteration %d: expected write error, got nil", i)
+		}
+		client.Close()
+		server.Close()
+	}
+	after := countOpenFds(t)
+	if after > before+5 {
+		t.Fatalf("file descriptors grew from %d to %d over 20 failed fragment writes", before, after)
+	}
+}
+
+// TestResilientTlsConnReorderOnlyDoesNotLeakFileDescriptors verifies the
+// reorder-only path closes the dup'd socket fd on failure.
+func TestResilientTlsConnReorderOnlyDoesNotLeakFileDescriptors(t *testing.T) {
+	record := buildClientHelloRecord(t)
+
+	before := countOpenFds(t)
+	for i := 0; i < 20; i++ {
+		client, server := newTcpPair(t)
+		client.SetWriteDeadline(time.Now().Add(-time.Second))
+		rconn := NewResilientTlsConn(client, false, true)
+		if _, err := rconn.Write(record); err == nil {
+			t.Fatalf("iteration %d: expected write error, got nil", i)
+		}
+		client.Close()
+		server.Close()
+	}
+	after := countOpenFds(t)
+	if after > before+5 {
+		t.Fatalf("file descriptors grew from %d to %d over 20 failed reorder writes", before, after)
+	}
+}

--- a/net_resilient_fail_closed_test.go
+++ b/net_resilient_fail_closed_test.go
@@ -1,0 +1,906 @@
+//go:build unix
+
+package connect
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// buildClientHelloRecord builds a TLS record (content type 22) carrying a
+// ClientHello with a server_name extension, the shape UnmarshalClientHello
+// needs to route into the fragment/reorder path.
+func buildClientHelloRecord(t *testing.T) []byte {
+	t.Helper()
+
+	var clientHello bytes.Buffer
+	clientHello.Write([]byte{0x03, 0x03}) // version TLS 1.2
+	clientHello.Write(make([]byte, 32))   // random
+	clientHello.WriteByte(0)              // session id length
+	clientHello.Write([]byte{0x00, 0x02}) // cipher suites length
+	clientHello.Write([]byte{0x13, 0x01}) // TLS_AES_128_GCM_SHA256
+	clientHello.WriteByte(1)              // compression methods length
+	clientHello.WriteByte(0)              // null
+
+	var serverName bytes.Buffer
+	serverName.WriteByte(0)              // host_name
+	serverName.Write([]byte{0x00, 0x0b}) // name length
+	serverName.WriteString("example.com")
+	var sniList bytes.Buffer
+	binary.Write(&sniList, binary.BigEndian, uint16(serverName.Len()))
+	sniList.Write(serverName.Bytes())
+
+	var extensions bytes.Buffer
+	binary.Write(&extensions, binary.BigEndian, uint16(0)) // server_name extension type
+	binary.Write(&extensions, binary.BigEndian, uint16(sniList.Len()))
+	extensions.Write(sniList.Bytes())
+
+	binary.Write(&clientHello, binary.BigEndian, uint16(extensions.Len()))
+	clientHello.Write(extensions.Bytes())
+
+	var handshake bytes.Buffer
+	handshake.WriteByte(1) // ClientHello
+	// uint24 length, written byte-wise (PutUint32 needs 4 bytes)
+	l := clientHello.Len()
+	handshake.WriteByte(byte(l >> 16))
+	handshake.WriteByte(byte(l >> 8))
+	handshake.WriteByte(byte(l))
+	handshake.Write(clientHello.Bytes())
+
+	record := make([]byte, 0, 5+handshake.Len())
+	record = append(record, 22) // handshake content type
+	record = append(record, 0x03, 0x03)
+	binary.BigEndian.PutUint16(append([]byte{}, 0, 0), uint16(handshake.Len()))
+	record = append(record, byte(handshake.Len()>>8), byte(handshake.Len()))
+	record = append(record, handshake.Bytes()...)
+
+	if _, meta := UnmarshalClientHello(handshake.Bytes()); meta == nil || meta.ServerNameValueEnd <= meta.ServerNameValueStart {
+		t.Fatalf("test ClientHello did not parse into the fragment path")
+	}
+	return record
+}
+
+// newTcpPair returns a connected TCP client/server pair on loopback.
+func newTcpPair(t *testing.T) (*net.TCPConn, *net.TCPConn) {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	serverCh := make(chan *net.TCPConn, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		serverCh <- conn.(*net.TCPConn)
+	}()
+	client, err := net.Dial("tcp4", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	var server *net.TCPConn
+	select {
+	case server = <-serverCh:
+	case err := <-errCh:
+		t.Fatalf("accept: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatalf("accept timeout")
+	}
+	// the listener is only needed to accept; close it so tests that create
+	// many pairs (e.g. the fd-leak check) do not accumulate listener fds
+	ln.Close()
+	t.Cleanup(func() {
+		client.Close()
+		server.Close()
+	})
+	return client.(*net.TCPConn), server
+}
+
+// socketTtl reads the socket TTL through a dup'd fd, like the resilient path.
+func socketTtl(t *testing.T, conn *net.TCPConn) int {
+	t.Helper()
+	f, err := conn.File()
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	defer f.Close()
+	return GetSocketTtl(SocketHandle(f.Fd()))
+}
+
+// setSocketTtl sets the socket TTL to ttl for the duration of the test.
+// The restore is best-effort: it runs during cleanup, after which the conn
+// may already be closed, so a failure there must not fail the test.
+func setSocketTtl(t *testing.T, conn *net.TCPConn, ttl int) {
+	t.Helper()
+	f, err := conn.File()
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	SetSocketTtl(SocketHandle(f.Fd()), ttl)
+	f.Close()
+	t.Cleanup(func() {
+		f, err := conn.File()
+		if err != nil {
+			return // conn already closed; nothing to restore
+		}
+		SetSocketTtl(SocketHandle(f.Fd()), 64)
+		f.Close()
+	})
+}
+
+// readTlsRecords reads raw TLS records from r and returns their
+// concatenated payloads. The resilient fragment path re-frames a record's
+// payload as multiple standalone TLS records, so reassembly is required to
+// compare against the original payload.
+func readTlsRecords(t *testing.T, r io.Reader, wantPayloadLen int) []byte {
+	t.Helper()
+	var payload []byte
+	for len(payload) < wantPayloadLen {
+		var hdr [5]byte
+		if _, err := io.ReadFull(r, hdr[:]); err != nil {
+			t.Fatalf("read record header: %v", err)
+		}
+		if hdr[0] != 22 {
+			t.Fatalf("record content type = %d, want 22", hdr[0])
+		}
+		recLen := int(hdr[3])<<8 | int(hdr[4])
+		rec := make([]byte, recLen)
+		if _, err := io.ReadFull(r, rec); err != nil {
+			t.Fatalf("read record body: %v", err)
+		}
+		payload = append(payload, rec...)
+	}
+	return payload
+}
+
+func TestResilientTlsConnFragmentRestoresTtlAndClosesFd(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, server := newTcpPair(t)
+	setSocketTtl(t, client, 42)
+
+	rconn := NewResilientTlsConn(client, true, true)
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+
+	// The socket TTL must be restored to the native value after the
+	// fragment write, on the success path.
+	if got := socketTtl(t, client); got != 42 {
+		t.Fatalf("socket TTL after fragmented write = %d, want 42 (native restored)", got)
+	}
+
+	// The peer must receive the full record payload (fragmentation re-frames
+	// the payload into standalone TLS records, so payloads concatenate back
+	// to the original handshake bytes).
+	got := readTlsRecords(t, server, len(record)-5)
+	if !bytes.Equal(got, record[5:]) {
+		t.Fatalf("peer received different payload than written")
+	}
+}
+
+func TestResilientTlsConnFragmentFailureDisablesAndRestoresTtl(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	// Keep a dup'd fd open across the failure: failConnection closes the
+	// original conn, but the socket TTL is a socket-level option visible
+	// through any fd, so the restore is checkable after the conn is closed.
+	probe, err := client.File()
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	defer probe.Close()
+	SetSocketTtl(SocketHandle(probe.Fd()), 42)
+
+	// Expire the write deadline so the first fragment write fails
+	// deterministically after the fd and native TTL are acquired.
+	client.SetWriteDeadline(time.Now().Add(-time.Second))
+
+	rconn := NewResilientTlsConn(client, true, true)
+	_, err = rconn.Write(record)
+	if err == nil {
+		t.Fatalf("write with expired deadline: expected error, got nil")
+	}
+
+	// The layer must be disabled and the connection closed so a retry
+	// cannot re-fragment the partially-sent record or append to it.
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after fragment write failure")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after fragment write failure: %d bytes", len(rconn.buffer))
+	}
+
+	// The socket TTL must be restored even on the failure path (via the
+	// dup'd fd; the original conn is closed by failConnection).
+	if got := GetSocketTtl(SocketHandle(probe.Fd())); got != 42 {
+		t.Fatalf("socket TTL after failed fragmented write = %d, want 42 (restored)", got)
+	}
+
+	// A subsequent Write must fail: the connection is closed after the
+	// indeterminate fragment state, so retries cannot corrupt the stream.
+	client.SetWriteDeadline(time.Time{})
+	if _, err := rconn.Write(record); err == nil {
+		t.Fatalf("write after fragment failure: expected error (conn closed), got nil")
+	}
+}
+
+func TestResilientTlsConnOffDrainsPartialRecord(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, server := newTcpPair(t)
+
+	rconn := NewResilientTlsConn(client, true, false)
+
+	// Write only part of a record: the header and 10 payload bytes. Write
+	// returns len(b), nil and buffers the rest.
+	partial := record[:15]
+	n, err := rconn.Write(partial)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(partial) {
+		t.Fatalf("write n=%d want %d", n, len(partial))
+	}
+	if len(rconn.buffer) != len(partial) {
+		t.Fatalf("buffered %d bytes, want %d", len(rconn.buffer), len(partial))
+	}
+
+	// Off must drain the buffered bytes to the wire before disabling, so
+	// the bytes an earlier Write accepted are not stranded. A successful
+	// drain returns nil.
+	if err := rconn.Off(); err != nil {
+		t.Fatalf("Off: unexpected error %v", err)
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after Off")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not drained by Off: %d bytes", len(rconn.buffer))
+	}
+
+	got := make([]byte, len(partial))
+	if _, err := io.ReadFull(server, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, partial) {
+		t.Fatalf("peer received different bytes than the drained partial record")
+	}
+}
+
+func TestResilientTlsConnReorderOnlyFragmentsOnFailure(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	probe, err := client.File()
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	defer probe.Close()
+	SetSocketTtl(SocketHandle(probe.Fd()), 42)
+
+	client.SetWriteDeadline(time.Now().Add(-time.Second))
+	rconn := NewResilientTlsConn(client, false, true)
+	_, err = rconn.Write(record)
+	if err == nil {
+		t.Fatalf("write with expired deadline: expected error, got nil")
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after reorder write failure")
+	}
+	if got := GetSocketTtl(SocketHandle(probe.Fd())); got != 42 {
+		t.Fatalf("socket TTL after failed reorder write = %d, want 42 (restored)", got)
+	}
+	client.SetWriteDeadline(time.Time{})
+	if _, err := rconn.Write(record); err == nil {
+		t.Fatalf("write after reorder failure: expected error (conn closed), got nil")
+	}
+}
+
+func TestResilientTlsConnReorderOnlySuccessRestoresTtl(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, server := newTcpPair(t)
+	setSocketTtl(t, client, 42)
+
+	rconn := NewResilientTlsConn(client, false, true)
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+
+	// The reorder-only path writes the record as a sequence of raw byte
+	// blocks (not re-wrapped as separate TLS records), so the peer must
+	// see the exact original bytes once reassembled.
+	if got := socketTtl(t, client); got != 42 {
+		t.Fatalf("socket TTL after reorder-only write = %d, want 42 (native restored)", got)
+	}
+
+	got := make([]byte, len(record))
+	if _, err := io.ReadFull(server, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, record) {
+		t.Fatalf("peer received different bytes than written")
+	}
+}
+
+func TestResilientTlsConnFragmentOnlySuccess(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, server := newTcpPair(t)
+
+	// fragment without reorder: this path does not touch the fd or TTL at
+	// all, only splits the record into standalone TLS records.
+	rconn := NewResilientTlsConn(client, true, false)
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+
+	got := readTlsRecords(t, server, len(record)-5)
+	if !bytes.Equal(got, record[5:]) {
+		t.Fatalf("peer received different payload than written")
+	}
+}
+
+func TestResilientTlsConnFragmentOnlyFailureDropsBuffer(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	// Expire the deadline so the first fragment write fails deterministically.
+	client.SetWriteDeadline(time.Now().Add(-time.Second))
+
+	rconn := NewResilientTlsConn(client, true, false)
+	_, err := rconn.Write(record)
+	if err == nil {
+		t.Fatalf("write with expired deadline: expected error, got nil")
+	}
+
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after fragment-only write failure")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after fragment-only write failure: %d bytes", len(rconn.buffer))
+	}
+
+	// A retry after the failure must fail: the connection is closed after
+	// the indeterminate fragment state, so retries cannot re-fragment the
+	// stale record or append to the corrupt stream.
+	client.SetWriteDeadline(time.Time{})
+	if _, err := rconn.Write(record); err == nil {
+		t.Fatalf("write after fragment failure: expected error (conn closed), got nil")
+	}
+}
+
+// countingFailConn wraps a net.Conn but is deliberately never a
+// *net.TCPConn, so ResilientTlsConn.Write must take the non-fd fallback
+// branch (self.conn.Write) for fragment handling instead of the TCPConn/fd
+// branch. The call-th Write (1-indexed) returns failErr instead of
+// forwarding to the underlying conn; every other call is forwarded so the
+// peer still observes the bytes that were actually sent. With shortWriteAt
+// set, that call returns a nil-error short write (writes shortN bytes, nil)
+// to exercise the short-write fail-closed paths.
+type countingFailConn struct {
+	net.Conn
+	calls        int
+	failAt       int
+	failErr      error
+	shortWriteAt int
+	shortN       int
+	closed       bool
+}
+
+// Close records that the resilient layer closed the connection, so the
+// fail-closed tests can assert the close actually happened rather than
+// inferring it from the buffer and enabled flag alone.
+func (c *countingFailConn) Close() error {
+	c.closed = true
+	return c.Conn.Close()
+}
+
+func (c *countingFailConn) Write(b []byte) (int, error) {
+	c.calls++
+	if c.shortWriteAt > 0 && c.calls == c.shortWriteAt {
+		n := c.shortN
+		if n > len(b) {
+			n = len(b)
+		}
+		if n, err := c.Conn.Write(b[:n]); err != nil {
+			return n, err
+		}
+		return n, nil
+	}
+	if c.failAt > 0 && c.calls == c.failAt {
+		return 0, c.failErr
+	}
+	return c.Conn.Write(b)
+}
+
+func TestResilientTlsConnNonTCPConnFragmentSuccess(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, server := newTcpPair(t)
+
+	wrapped := &countingFailConn{Conn: client}
+	rconn := NewResilientTlsConn(wrapped, true, false)
+
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+	if wrapped.calls == 0 {
+		t.Fatalf("expected writes to be forwarded through the wrapped non-TCPConn")
+	}
+
+	got := readTlsRecords(t, server, len(record)-5)
+	if !bytes.Equal(got, record[5:]) {
+		t.Fatalf("peer received different payload than written")
+	}
+}
+
+func TestResilientTlsConnNonTCPConnFragmentFailureDropsBuffer(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	failErr := errors.New("injected write failure")
+	wrapped := &countingFailConn{Conn: client, failAt: 1, failErr: failErr}
+	rconn := NewResilientTlsConn(wrapped, true, false)
+
+	_, err := rconn.Write(record)
+	if !errors.Is(err, failErr) {
+		t.Fatalf("write error = %v, want %v", err, failErr)
+	}
+
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after non-TCPConn fragment write failure")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after non-TCPConn fragment write failure: %d bytes", len(rconn.buffer))
+	}
+
+	// The layer must also close the underlying connection, so a later
+	// write fails instead of appending to the corrupt stream. Without this
+	// the test would pass even if failConnection stopped closing.
+	if !wrapped.closed {
+		t.Fatalf("underlying connection not closed after a failed write")
+	}
+}
+
+func TestResilientTlsConnOffNoopWhenBufferEmpty(t *testing.T) {
+	client, server := newTcpPair(t)
+	rconn := NewResilientTlsConn(client, true, false)
+
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not empty before Off: %d bytes", len(rconn.buffer))
+	}
+
+	// Off on an empty buffer is a no-op and returns nil.
+	if err := rconn.Off(); err != nil {
+		t.Fatalf("Off: unexpected error %v", err)
+	}
+
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after Off")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer unexpectedly non-empty after a no-op Off: %d bytes", len(rconn.buffer))
+	}
+
+	// Nothing should have been written to the peer since the buffer was
+	// empty; the read must time out rather than return data.
+	server.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	one := make([]byte, 1)
+	_, err := server.Read(one)
+	if err == nil {
+		t.Fatalf("peer unexpectedly received data from a no-op Off")
+	}
+	if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+		t.Fatalf("unexpected error waiting for no data: %v", err)
+	}
+}
+
+// buildRawRecord builds a single TLS record of the given content type
+// wrapping payload, using TlsVersion1_2 as the record version. Unlike
+// buildClientHelloRecord, the payload is not required to parse as a
+// ClientHello, so this is used to reach the raw-record flush branches
+// (non-handshake content types, and handshake records that are not a
+// ClientHello with a server_name extension).
+func buildRawRecord(contentType TlsContentType, payload []byte) []byte {
+	header := &tlsHeader{contentType: contentType, tlsVersion: TlsVersion1_2}
+	return header.reconstruct(payload)
+}
+
+// buildNonClientHelloHandshakeRecord builds a Handshake-content-type record
+// whose body is not a ClientHello (message type 2, e.g. a ServerHello
+// framing), so UnmarshalClientHello returns (nil, nil) and Write must take
+// the raw-record flush branch instead of the fragment/reorder path.
+func buildNonClientHelloHandshakeRecord() []byte {
+	handshakeBody := []byte{0xAA, 0xBB, 0xCC}
+	handshake := make([]byte, 0, 4+len(handshakeBody))
+	handshake = append(handshake, 2) // ServerHello, not ClientHello (type 1)
+	l := len(handshakeBody)
+	handshake = append(handshake, byte(l>>16), byte(l>>8), byte(l))
+	handshake = append(handshake, handshakeBody...)
+	return buildRawRecord(TlsContentTypeHandshake, handshake)
+}
+
+// shortWriteConn wraps a net.Conn and, on the shortAt-th call (1-indexed) to
+// Write, forwards only shortN of the requested bytes to the underlying conn
+// and returns (shortN, nil) instead of the full length. This exercises the
+// "short write, no error" branch the PR added checks for: prior to the PR,
+// only err != nil was checked, so a short write with a nil error would have
+// been treated as a full, successful send. Close is tracked so tests can
+// confirm failConnection actually closes the wrapped connection.
+type shortWriteConn struct {
+	net.Conn
+	calls   int
+	shortAt int
+	shortN  int
+	closed  bool
+}
+
+func (c *shortWriteConn) Write(b []byte) (int, error) {
+	c.calls++
+	if c.shortAt > 0 && c.calls == c.shortAt {
+		n := c.shortN
+		if len(b) < n {
+			n = len(b)
+		}
+		if 0 < n {
+			if _, err := c.Conn.Write(b[:n]); err != nil {
+				return 0, err
+			}
+		}
+		return n, nil
+	}
+	return c.Conn.Write(b)
+}
+
+func (c *shortWriteConn) Close() error {
+	c.closed = true
+	return c.Conn.Close()
+}
+
+func TestResilientTlsConnNonHandshakeRecordFlushSuccess(t *testing.T) {
+	record := buildRawRecord(TlsContentTypeApplicationData, []byte("application data payload"))
+	client, server := newTcpPair(t)
+
+	// non-handshake content types (e.g. application data) never enter the
+	// fragment/reorder logic; Write must flush the raw record unmodified.
+	rconn := NewResilientTlsConn(client, true, true)
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+
+	got := make([]byte, len(record))
+	if _, err := io.ReadFull(server, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, record) {
+		t.Fatalf("peer received different bytes than written")
+	}
+}
+
+func TestResilientTlsConnNonHandshakeRecordShortWriteFailsConnection(t *testing.T) {
+	record := buildRawRecord(TlsContentTypeApplicationData, []byte("application data payload"))
+	client, _ := newTcpPair(t)
+
+	// short-write (nil error, n < len) on the very first flush of the raw
+	// record must be treated as a failure, not a successful send.
+	wrapped := &shortWriteConn{Conn: client, shortAt: 1, shortN: 3}
+	rconn := NewResilientTlsConn(wrapped, true, true)
+
+	n, err := rconn.Write(record)
+	// The flush branch's short-write check must surface a non-nil error
+	// (io.ErrShortWrite) when the write comes up short with a nil error, so
+	// the caller never mistakes a closed connection for success.
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("write error = %v, want io.ErrShortWrite", err)
+	}
+	if n != 0 {
+		t.Fatalf("write n=%d want 0", n)
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after short-write flush failure")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after short-write flush failure: %d bytes", len(rconn.buffer))
+	}
+	if !wrapped.closed {
+		t.Fatalf("underlying connection not closed after short-write flush failure")
+	}
+}
+
+func TestResilientTlsConnHandshakeWithoutClientHelloFlushSuccess(t *testing.T) {
+	record := buildNonClientHelloHandshakeRecord()
+	client, server := newTcpPair(t)
+
+	// a Handshake-content-type record that is not a ClientHello with SNI
+	// must be flushed as a raw record rather than routed into the
+	// fragment/reorder logic.
+	rconn := NewResilientTlsConn(client, true, true)
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+
+	got := make([]byte, len(record))
+	if _, err := io.ReadFull(server, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, record) {
+		t.Fatalf("peer received different bytes than written")
+	}
+}
+
+func TestResilientTlsConnHandshakeWithoutClientHelloShortWriteFailsConnection(t *testing.T) {
+	record := buildNonClientHelloHandshakeRecord()
+	client, _ := newTcpPair(t)
+
+	wrapped := &shortWriteConn{Conn: client, shortAt: 1, shortN: 2}
+	rconn := NewResilientTlsConn(wrapped, true, true)
+
+	n, err := rconn.Write(record)
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("write error = %v, want io.ErrShortWrite", err)
+	}
+	if n != 0 {
+		t.Fatalf("write n=%d want 0", n)
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after short-write flush failure")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after short-write flush failure: %d bytes", len(rconn.buffer))
+	}
+	if !wrapped.closed {
+		t.Fatalf("underlying connection not closed after short-write flush failure")
+	}
+}
+
+func TestResilientTlsConnTcpNeitherFragmentNorReorderSuccess(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, server := newTcpPair(t)
+
+	// fragment=false, reorder=false with a *net.TCPConn takes the plain
+	// tcpConn.Write(record) branch: no ttl/fd manipulation, no splitting.
+	rconn := NewResilientTlsConn(client, false, false)
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+
+	got := make([]byte, len(record))
+	if _, err := io.ReadFull(server, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, record) {
+		t.Fatalf("peer received different bytes than written")
+	}
+}
+
+func TestResilientTlsConnTcpNeitherFragmentNorReorderFailureClosesConnection(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	client.SetWriteDeadline(time.Now().Add(-time.Second))
+	rconn := NewResilientTlsConn(client, false, false)
+
+	if _, err := rconn.Write(record); err == nil {
+		t.Fatalf("write with expired deadline: expected error, got nil")
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after write failure")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after write failure: %d bytes", len(rconn.buffer))
+	}
+
+	client.SetWriteDeadline(time.Time{})
+	if _, err := rconn.Write(record); err == nil {
+		t.Fatalf("write after failure: expected error (conn closed), got nil")
+	}
+}
+
+func TestResilientTlsConnNonTCPConnNoFragmentSuccess(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, server := newTcpPair(t)
+
+	// self.conn is not a *net.TCPConn and fragment is false: Write must
+	// take the self.conn.Write(record) fallback (net_resilient.go's
+	// "else" branch under "if self.fragment {...} else {...}" for the
+	// non-TCPConn path), sending the whole record as one call.
+	wrapped := &countingFailConn{Conn: client}
+	rconn := NewResilientTlsConn(wrapped, false, true)
+
+	n, err := rconn.Write(record)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(record) {
+		t.Fatalf("write n=%d want %d", n, len(record))
+	}
+	if wrapped.calls != 1 {
+		t.Fatalf("expected exactly one forwarded write, got %d", wrapped.calls)
+	}
+
+	got := make([]byte, len(record))
+	if _, err := io.ReadFull(server, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, record) {
+		t.Fatalf("peer received different bytes than written")
+	}
+}
+
+func TestResilientTlsConnNonTCPConnNoFragmentShortWriteFailsConnection(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	wrapped := &shortWriteConn{Conn: client, shortAt: 1, shortN: 4}
+	rconn := NewResilientTlsConn(wrapped, false, true)
+
+	n, err := rconn.Write(record)
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("write error = %v, want io.ErrShortWrite", err)
+	}
+	if n != 0 {
+		t.Fatalf("write n=%d want 0", n)
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after non-TCPConn short-write failure")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after non-TCPConn short-write failure: %d bytes", len(rconn.buffer))
+	}
+	if !wrapped.closed {
+		t.Fatalf("underlying connection not closed after non-TCPConn short-write failure")
+	}
+}
+
+func TestResilientTlsConnOffDrainFailureClosesConnection(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	// Fail the drain write through the wrapper rather than pre-closing the
+	// conn: pre-closing makes the close that Off performs unobservable, so
+	// the test could not distinguish a fail-closed Off from one that leaves
+	// the connection open.
+	failErr := errors.New("drain failed")
+	wrapped := &countingFailConn{Conn: client, failAt: 1, failErr: failErr}
+	rconn := NewResilientTlsConn(wrapped, true, false)
+
+	partial := record[:15]
+	n, err := rconn.Write(partial)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(partial) {
+		t.Fatalf("write n=%d want %d", n, len(partial))
+	}
+	if len(rconn.buffer) != len(partial) {
+		t.Fatalf("buffered %d bytes, want %d", len(rconn.buffer), len(partial))
+	}
+
+	// A failed drain must surface as a non-nil error, not a silent success:
+	// the caller hands the connection back as established, so a silent
+	// failure would present a closed conn as live.
+	if err := rconn.Off(); err == nil {
+		t.Fatalf("Off: expected drain error, got nil")
+	}
+
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after Off")
+	}
+	// A failed drain leaves the wire state indeterminate: the connection is
+	// closed and the buffer cleared so nothing can be appended to the
+	// partial stream.
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not cleared after a failed drain: got %d bytes", len(rconn.buffer))
+	}
+
+	// The layer must also close the underlying connection, so a later
+	// write fails instead of appending to the corrupt stream. Without this
+	// the test would pass even if failConnection stopped closing.
+	if !wrapped.closed {
+		t.Fatalf("underlying connection not closed after a failed write")
+	}
+}
+
+// TestResilientTlsConnNonTCPConnFragmentShortWrite verifies a short write
+// with a nil error on the fragment path fails the connection and returns a
+// non-nil error (io.ErrShortWrite), never a nil error after closing.
+func TestResilientTlsConnNonTCPConnFragmentShortWrite(t *testing.T) {
+	record := buildClientHelloRecord(t)
+	client, _ := newTcpPair(t)
+
+	wrapped := &countingFailConn{Conn: client, shortWriteAt: 1, shortN: 1}
+	rconn := NewResilientTlsConn(wrapped, true, false)
+
+	_, err := rconn.Write(record)
+	if err == nil {
+		t.Fatalf("short write: expected non-nil error, got nil")
+	}
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("short write error = %v, want io.ErrShortWrite", err)
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after short write")
+	}
+	if len(rconn.buffer) != 0 {
+		t.Fatalf("buffer not dropped after short write: %d bytes", len(rconn.buffer))
+	}
+
+	// The layer must also close the underlying connection, so a later
+	// write fails instead of appending to the corrupt stream. Without this
+	// the test would pass even if failConnection stopped closing.
+	if !wrapped.closed {
+		t.Fatalf("underlying connection not closed after a failed write")
+	}
+}
+
+// TestResilientTlsConnNonTCPConnRawRecordShortWrite verifies a short write
+// on the raw-record flush path (non-handshake content type) fails the
+// connection and returns io.ErrShortWrite. The test uses a plain TLS
+// record with an application-data content type so it takes the raw flush
+// path rather than the fragment path.
+func TestResilientTlsConnNonTCPConnRawRecordShortWrite(t *testing.T) {
+	// Build a non-handshake TLS record: content type 23 (application data)
+	// so Write takes the raw flush path.
+	payload := []byte("hello world")
+	record := make([]byte, 0, 5+len(payload))
+	record = append(record, 23)
+	record = append(record, 0x03, 0x03)
+	record = append(record, byte(len(payload)>>8), byte(len(payload)))
+	record = append(record, payload...)
+
+	client, _ := newTcpPair(t)
+	wrapped := &countingFailConn{Conn: client, shortWriteAt: 1, shortN: 2}
+	rconn := NewResilientTlsConn(wrapped, true, false)
+
+	_, err := rconn.Write(record)
+	if err == nil {
+		t.Fatalf("short write: expected non-nil error, got nil")
+	}
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("short write error = %v, want io.ErrShortWrite", err)
+	}
+	if rconn.Enabled() {
+		t.Fatalf("layer still enabled after short write")
+	}
+
+	// The layer must also close the underlying connection, so a later
+	// write fails instead of appending to the corrupt stream. Without this
+	// the test would pass even if failConnection stopped closing.
+	if !wrapped.closed {
+		t.Fatalf("underlying connection not closed after a failed write")
+	}
+}

--- a/net_resilient_test.go
+++ b/net_resilient_test.go
@@ -48,8 +48,8 @@ func (self *immediateWriteConn) SetWriteDeadline(deadline time.Time) error {
 func TestResilientTlsConnOffWritesDirectly(t *testing.T) {
 	underlying := &immediateWriteConn{}
 	conn := NewResilientTlsConn(underlying, true, true)
-	conn.Off()
-	conn.Off()
+	_ = conn.Off()
+	_ = conn.Off()
 
 	message := []byte("application data")
 	n, err := conn.Write(message)
@@ -64,7 +64,7 @@ func TestResilientTlsConnOffWritesDirectly(t *testing.T) {
 func BenchmarkResilientTlsConnDisabledWrite(b *testing.B) {
 	underlying := &immediateWriteConn{}
 	conn := NewResilientTlsConn(underlying, true, true)
-	conn.Off()
+	_ = conn.Off()
 	message := make([]byte, 3*1024)
 
 	b.ReportAllocs()


### PR DESCRIPTION
The resilient fragment/reorder layer is what gets us to the platform and to extenders through networks that fingerprint or block TLS by SNI (the Jigsaw/Outline record-fragmentation trick, link is in `net_resilient.go`). It has three bugs on its failure paths.

**1. `Off()` strands a partial buffered record.**

`Off()` disabled the layer without draining `self.buffer`. An earlier `Write` had already returned `len(b), nil` for those bytes, so they just vanished while the caller thought they were on the wire. `Off()` now drains first. If that drain fails or comes up short, the connection is failed closed and the error comes back to the caller, so we stop handing out a dead connection as if it were established.

**2. A failed fragment write corrupts the retry.**

The fragment path splits a TLS record's payload and re-frames each piece as its own record. If a write partway through fails, the earlier fragments are already on the wire but the buffer still holds the whole record. Retrying re-fragments from the start and the peer sees those first fragments twice, which corrupts the handshake stream. On top of that the connection stayed open and writable, so later writes just appended to a stream that was already garbage.

Every fragment and raw-record write now goes through `writeRecord`. It converts a short write with a nil error into `io.ErrShortWrite`, drops the buffered record, disables the layer, and closes the connection so later writes fail instead of piling onto the corruption.

**3. The socket TTL wasn't restored on failure.**

The fragment/reorder paths change the socket TTL to force retransmits. The restore only ran when everything succeeded, so a failed fragment write left the socket sitting at the altered TTL. Both TCP branches now defer the restore once the native TTL has been validated, so it runs on every exit path and before the dup'd fd closes.

**API change:** `Off()` now returns `error`. Both in-tree callers are updated here.

**Behavior change, deliberate:** a failure on the very first fragment (nothing on the wire yet, buffered record still intact) used to leave the connection retryable, and now it fails closed. That's fine in practice. `crypto/tls` marks the connection broken on any write error anyway, so the record was never going to be retried coherently.

24 tests. Short-write injection on the fragment, reorder, and raw-record paths, checking that a nil-error short write surfaces `io.ErrShortWrite` rather than looking like success on a connection we just closed. TTL restore is verified on the failure path. `Off()` is covered for a clean drain, an empty buffer, and a failed drain. The two fd tests in the Linux-only file aren't regression tests, they're guards confirming the existing `defer f.Close()` still covers the new early returns.

Two notes so neither gets pinned on this branch. `extender.TestExtender` currently fails on `main` too, with or without these changes. `TestFramerSpeedup` asserts a throughput ratio, so it fails on a loaded machine and passes on an idle one; I saw that on `main` and on this branch equally. Everything else passes.
