### PR TITLE
feat(routing): class-aware scored exit placement — scoring foundation, inert by default

### DIFF
--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -973,6 +973,15 @@ type MultiClientSettings struct {
 	// since the previous one, so an idle session costs nothing.
 	HeartbeatInterval time.Duration
 
+	// Smart routing (Phase 1), all zero-value-off so an override from an older
+	// struct keeps today's placement. ScoredPlacement is the master gate;
+	// PlacementHysteresisPct==0 is plain greater-than; PlacementDemoteConsecutive<=1
+	// acts on every sample; RewardInstrumentation==false emits no reward lines.
+	ScoredPlacement            bool
+	PlacementHysteresisPct     float64
+	PlacementDemoteConsecutive int
+	RewardInstrumentation      bool
+
 	SecurityPolicyGenerator func(context.Context, *SecurityPolicyStatsCollector) SecurityPolicy
 
 	// the epoch for flushing block action and packet stats events to listeners
@@ -2107,6 +2116,15 @@ type ReliabilitySettings struct {
 	// capture is sometimes taken with the beat turned up to spot a transition,
 	// and sometimes with it off to keep an hour of buffer for something else.
 	HeartbeatInterval time.Duration
+
+	// Smart routing (Phase 1), all zero-value-off so an override from an older
+	// struct keeps today's placement. ScoredPlacement is the master gate;
+	// PlacementHysteresisPct==0 is plain greater-than; PlacementDemoteConsecutive<=1
+	// acts on every sample; RewardInstrumentation==false emits no reward lines.
+	ScoredPlacement            bool
+	PlacementHysteresisPct     float64
+	PlacementDemoteConsecutive int
+	RewardInstrumentation      bool
 }
 
 // ReliabilitySettingsFrom reads the effective values out of a settings struct.
@@ -2154,6 +2172,11 @@ func ReliabilitySettingsFrom(settings *MultiClientSettings) *ReliabilitySettings
 		SchedulerPauseRecoveryTimeout:      settings.SchedulerPauseRecoveryTimeout,
 		BlackholeConnectComparativeTimeout: settings.BlackholeConnectComparativeTimeout,
 		HeartbeatInterval:                  settings.HeartbeatInterval,
+
+		ScoredPlacement:            settings.ScoredPlacement,
+		PlacementHysteresisPct:     settings.PlacementHysteresisPct,
+		PlacementDemoteConsecutive: settings.PlacementDemoteConsecutive,
+		RewardInstrumentation:      settings.RewardInstrumentation,
 	}
 }
 

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -1178,6 +1178,15 @@ type RemoteUserNatMultiClient struct {
 	flowOwnerLock       sync.Mutex
 	flowOwner4          map[Ip4Path]flowOwnerEntry
 	flowOwner6          map[Ip6Path]flowOwnerEntry
+	// the smart-routing classifier seam (Phase 1): the platform's traffic
+	// classifier, installed by SetFlowClassifier. Mirrors flowOwnerFunc
+	// exactly -- atomic pointer, nil clears, one-branch nil cost paid via
+	// classifyOrUnknown (routing_class.go). Zero value is fully inert: no
+	// constructor wiring is required and bare fixtures are unaffected.
+	// Consulted ONLY from the guarded scored-placement path (see
+	// scoredPlacementEnabled); with that gate off, or with no classifier
+	// installed, nothing in this file's new routing code runs.
+	flowClassifier atomic.Pointer[FlowClassifier]
 	// appPinClients is the cross-version half of an app pin: the exit an
 	// app's flows are currently placed on, keyed by app id. The affinity
 	// groups are per-ip-version by construction (separate path maps), so a
@@ -1340,6 +1349,26 @@ func (self *RemoteUserNatMultiClient) SetFlowOwnerLookup(lookup FlowOwnerLookupF
 	self.stateLock.Lock()
 	defer self.stateLock.Unlock()
 	self.clearAppPinsWithLock()
+}
+
+// SetFlowClassifier installs (or, with nil, removes) the smart-routing
+// traffic classifier. Mirrors SetFlowOwnerLookup: a bare atomic store, safe
+// at runtime and on a bare client. Installing a classifier does not, by
+// itself, change placement -- scoredPlacementEnabled must also be true (see
+// the guarded branch in sendPacket's placement helper), so this is inert
+// until both are true, matching every other nil-func convention in this
+// file.
+func (self *RemoteUserNatMultiClient) SetFlowClassifier(c FlowClassifier) {
+	loggerOrDefault(self.log).Infof("%s\n", relEvent(
+		"flow_classifier",
+		"installed", c != nil,
+	))
+
+	if c == nil {
+		self.flowClassifier.Store(nil)
+	} else {
+		self.flowClassifier.Store(&c)
+	}
 }
 
 // flowOwnerAppId answers "which pinned app owns this flow" -- from the cache
@@ -2190,6 +2219,15 @@ func (self *RemoteUserNatMultiClient) reliabilitySettings() *ReliabilitySettings
 	return ReliabilitySettingsFrom(self.settings)
 }
 
+// scoredPlacementEnabled is the single gate the placement path checks. When
+// false (the zero value, and every current build's default) selection is
+// exactly today's; nothing in this file's new routing code runs. See the
+// guarded branch in sendPacket's placement helper (coalesceOrderedClients)
+// and scoredPlacementReorder.
+func scoredPlacementEnabled(r *ReliabilitySettings) bool {
+	return r != nil && r.ScoredPlacement
+}
+
 // SetReliabilitySettings installs runtime overrides for the reliability knobs.
 // nil clears them, restoring the constructed settings. Takes effect on the next
 // packet -- no reconnect needed, which is the point: a freeze can be A/B'd
@@ -2481,6 +2519,101 @@ func (self *RemoteUserNatMultiClient) leastLoadedClients(clients []*multiClientC
 		}
 	}
 	return least
+}
+
+// scoredPlacementReorder is the Phase 1 scored-placement path, called ONLY
+// when scoredPlacementEnabled is true (see the guarded branch in sendPacket's
+// coalesceOrderedClients). It NEVER changes which exits are eligible --
+// candidates has already been through raceCandidates' verdict/quarantine/
+// tier/flow-cap gates -- it only ever re-orders that already-healthy field,
+// promoting the scorer's pick to the front. The learner never overrides the
+// safety layer: membership is untouched, only order.
+//
+// classifyOrUnknown is nil-safe, so an unset flowClassifier (every build
+// today -- no classifier implementation exists yet; it lands in a later
+// phase) always classifies ClassUnknown, which returns candidates completely
+// untouched: there is nothing to score against. This is what makes turning
+// ScoredPlacement on, by itself, a no-op today -- behavior only ever
+// *refines*, never regresses, once a real classifier is installed.
+func (self *RemoteUserNatMultiClient) scoredPlacementReorder(candidates []*multiClientChannel, ipPath *IpPath, appId string) []*multiClientChannel {
+	if len(candidates) < 2 {
+		// nothing to reorder
+		return candidates
+	}
+
+	var classifier FlowClassifier
+	if p := self.flowClassifier.Load(); p != nil {
+		classifier = *p
+	}
+	class := classifyOrUnknown(classifier, ipPath, appId).Class
+	if class == ClassUnknown {
+		// no classifier installed, or it declined to name a class: nothing to
+		// score against, so the field stands in the legacy order raceCandidates
+		// already computed.
+		return candidates
+	}
+
+	// flow counts are parent-lock state (the same bookkeeping
+	// leastLoadedClients reads above), gathered in one locked pass and then
+	// scored with no lock held. WindowStats (the per-exit goodput source used
+	// elsewhere in this file, e.g. the resize pass) has the side effect of
+	// advancing the channel's healthy/unhealthy duration bookkeeping, tuned
+	// for that pass's ~15s cadence -- calling it here, at new-flow frequency,
+	// would perturb that state at a much higher rate for no benefit yet. So
+	// RttMillis, GoodputBytesPerSec, and Jitter are left at their zero value
+	// (see exitMetricsSnapshot); real per-exit telemetry for those is future
+	// work, once a side-effect-free accessor exists.
+	flowCounts := make(map[*multiClientChannel]int, len(candidates))
+	func() {
+		self.stateLock.Lock()
+		defer self.stateLock.Unlock()
+		for _, c := range candidates {
+			flowCounts[c] = len(self.clientUpdates[c])
+		}
+	}()
+
+	weights := classWeights(class)
+	hysteresisPct := self.reliabilitySettings().PlacementHysteresisPct
+
+	bestIndex := 0
+	bestFlows := flowCounts[candidates[0]]
+	bestScore := exitScore(exitMetricsSnapshot(bestFlows), weights)
+	for i := 1; i < len(candidates); i++ {
+		flows := flowCounts[candidates[i]]
+		score := exitScore(exitMetricsSnapshot(flows), weights)
+		if lessLoadedTieBreak(bestScore, score, bestFlows, flows, hysteresisPct) {
+			bestIndex, bestScore, bestFlows = i, score, flows
+		}
+	}
+	if bestIndex == 0 {
+		return candidates
+	}
+
+	reordered := make([]*multiClientChannel, 0, len(candidates))
+	reordered = append(reordered, candidates[bestIndex])
+	for i, c := range candidates {
+		if i != bestIndex {
+			reordered = append(reordered, c)
+		}
+	}
+	return reordered
+}
+
+// exitMetricsSnapshot builds the scorer's read of one candidate from what is
+// safely available on the placement path today: Flows, the same live
+// flow-cap bookkeeping leastLoadedClients already reads. RttMillis,
+// GoodputBytesPerSec, and Jitter have no per-exit accessor that is safe to
+// call at new-flow frequency without perturbing the resize pass's health
+// bookkeeping (see scoredPlacementReorder) and StallEvents has no per-exit
+// counter in this file at all yet (stall state here is a boolean, not a
+// count). All four are left at their zero value, which contributes the SAME
+// constant to every candidate's score (see exitScore's hostile-input guards,
+// which already treat a zero RTT/Jitter/StallEvents as a valid, sanitized
+// input) -- so today scoredPlacementReorder reduces to the less-loaded
+// tie-break among classified candidates. Wiring real per-exit telemetry is
+// later-phase work; see the Task 8 report for the reasoning.
+func exitMetricsSnapshot(flows int) ExitMetrics {
+	return ExitMetrics{Flows: flows}
 }
 
 // bindClientFlow records that a flow is now committed to client, which is what
@@ -4657,6 +4790,15 @@ func (self *RemoteUserNatMultiClient) sendPacket(
 			for _, windowType := range self.selectWindowTypes(sendPacket) {
 				if window, ok := self.windows[windowType]; ok {
 					orderedClients := self.raceCandidates(window)
+					if scoredPlacementEnabled(self.reliabilitySettings()) {
+						// guarded scored-placement path (Phase 1): re-orders the
+						// already health-filtered field above, never widens or
+						// narrows it. See scoredPlacementReorder.
+						orderedClients = self.scoredPlacementReorder(orderedClients, ipPath, sendPacket.pin.appId)
+					}
+					// legacy selection unchanged: with the gate off (every
+					// current build's default), orderedClients is exactly what
+					// raceCandidates returned, untouched.
 					if 0 < len(orderedClients) {
 						return orderedClients
 					}

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -9241,9 +9241,22 @@ type multiClientChannel struct {
 	// clearQuarantineWithLock). Feeds benchDuration so a channel that keeps
 	// re-earning a bench holds it longer each time (RFC 2439-style flap
 	// damping) instead of the constant hold every episode got before this
-	// task. Deliberately session-scoped and never persisted or decayed --
-	// same lifetime as quarantineMigrated and the rest of the episode
-	// bookkeeping beside it, not new durable state. Guarded by stateLock.
+	// task. Deliberately session-scoped and never persisted -- same lifetime
+	// as quarantineMigrated and the rest of the episode bookkeeping beside
+	// it, not new durable state. Guarded by stateLock.
+	//
+	// KNOWN LIMITATION, tracked separately, not yet fixed: this counter never
+	// DECAYS within a session -- a provider that flaps early and then runs
+	// clean for hours still escalates straight to the 240s cap on its next
+	// bench rather than re-starting at 60s. The blast radius is bounded and
+	// self-healing even so: the worst case is a stale-bad exit taking up to
+	// 240s instead of 60s to be force-evicted by the expiry escape, and
+	// release-on-receive-progress (addReceiveAck's clear, unrelated to this
+	// counter) remains a fully independent per-poll acquittal path this
+	// cannot delay -- a genuinely recovered exit is never held past the
+	// evidence that acquits it. Clean-interval decay analogous to
+	// quarantineMemoryDuration should land before QuarantineDampening is
+	// ever turned on for real traffic.
 	quarantineReconvictions int
 
 	// pendingSendTime is when the current run of unacked sends began, reset on
@@ -11609,16 +11622,19 @@ func (self *multiClientChannel) detectBlackhole() {
 				if quarantineReason, quarantineStart := self.quarantineState(); quarantineReason == reason {
 					quarantinedSince = quarantineStart
 				}
-				// the bench hold time: benchDuration(reconvictions, base,
-				// dampening off) returns base unchanged, so with
-				// QuarantineDampening at its zero value this is byte-for-byte
+				// the bench hold time: short-circuited on the knob BEFORE
+				// quarantineReconvictionCount() (which takes stateLock) is
+				// ever called, so a default build with QuarantineDampening
+				// off does not acquire a new lock on this live path -- the
+				// off-path value stays byte-for-byte
 				// self.settings.StatsWindowKeepUnhealthyDuration, exactly as
-				// it was passed directly before this task.
-				quarantineExpiry := benchDuration(
-					self.quarantineReconvictionCount(),
-					self.settings.StatsWindowKeepUnhealthyDuration,
-					self.reliabilitySettings().QuarantineDampening,
-				)
+				// it was passed directly before this task. benchDuration's
+				// own `if !dampening { return base }` guard is kept as
+				// defence in depth, not relied on here for the lock-skip.
+				quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration
+				if dampening := self.reliabilitySettings().QuarantineDampening; dampening {
+					quarantineExpiry = benchDuration(self.quarantineReconvictionCount(), quarantineExpiry, dampening)
+				}
 				action := verdictAction(
 					reason,
 					self.reliabilitySettings().SoftVerdictDemote,

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -11631,9 +11631,12 @@ func (self *multiClientChannel) detectBlackhole() {
 				// it was passed directly before this task. benchDuration's
 				// own `if !dampening { return base }` guard is kept as
 				// defence in depth, not relied on here for the lock-skip.
+				// dampening is always true inside this branch (that is the
+				// condition), so it is passed to benchDuration as a literal
+				// rather than re-read.
 				quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration
-				if dampening := self.reliabilitySettings().QuarantineDampening; dampening {
-					quarantineExpiry = benchDuration(self.quarantineReconvictionCount(), quarantineExpiry, dampening)
+				if self.reliabilitySettings().QuarantineDampening {
+					quarantineExpiry = benchDuration(self.quarantineReconvictionCount(), quarantineExpiry, true)
 				}
 				action := verdictAction(
 					reason,

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -982,6 +982,16 @@ type MultiClientSettings struct {
 	PlacementDemoteConsecutive int
 	RewardInstrumentation      bool
 
+	// Quarantine flap damping (Phase 1), zero-value-off like the rest of this
+	// block. QuarantineDampening false leaves benchDuration returning the
+	// constant StatsWindowKeepUnhealthyDuration it always has -- today's
+	// behavior. QuarantineReentryRamp==0 disables the released-exit score
+	// ramp entirely, so a lifted quarantine returns to full scored-placement
+	// standing immediately, exactly as before this task. See benchDuration
+	// and reentryScorePenalty.
+	QuarantineDampening   bool
+	QuarantineReentryRamp time.Duration
+
 	SecurityPolicyGenerator func(context.Context, *SecurityPolicyStatsCollector) SecurityPolicy
 
 	// the epoch for flushing block action and packet stats events to listeners
@@ -2154,6 +2164,11 @@ type ReliabilitySettings struct {
 	PlacementHysteresisPct     float64
 	PlacementDemoteConsecutive int
 	RewardInstrumentation      bool
+
+	// the quarantine flap-damping pair; see the matching MultiClientSettings
+	// fields for what each one does
+	QuarantineDampening   bool
+	QuarantineReentryRamp time.Duration
 }
 
 // ReliabilitySettingsFrom reads the effective values out of a settings struct.
@@ -2206,6 +2221,9 @@ func ReliabilitySettingsFrom(settings *MultiClientSettings) *ReliabilitySettings
 		PlacementHysteresisPct:     settings.PlacementHysteresisPct,
 		PlacementDemoteConsecutive: settings.PlacementDemoteConsecutive,
 		RewardInstrumentation:      settings.RewardInstrumentation,
+
+		QuarantineDampening:   settings.QuarantineDampening,
+		QuarantineReentryRamp: settings.QuarantineReentryRamp,
 	}
 }
 
@@ -2574,13 +2592,18 @@ func (self *RemoteUserNatMultiClient) scoredPlacementReorder(candidates []*multi
 
 	weights := classWeights(class)
 	hysteresisPct := self.reliabilitySettings().PlacementHysteresisPct
+	// the re-entry ramp: 0 (QuarantineReentryRamp's zero value) makes every
+	// reentryPenalty call below return 0 unconditionally, so this loop's
+	// scores are byte-for-byte exitScore(...) with no penalty applied --
+	// exactly as before this task.
+	reentryRamp := self.reliabilitySettings().QuarantineReentryRamp
 
 	bestIndex := 0
 	bestFlows := flowCounts[candidates[0]]
-	bestScore := exitScore(exitMetricsSnapshot(bestFlows), weights)
+	bestScore := exitScore(exitMetricsSnapshot(bestFlows), weights) - candidates[0].reentryPenalty(reentryRamp)
 	for i := 1; i < len(candidates); i++ {
 		flows := flowCounts[candidates[i]]
-		score := exitScore(exitMetricsSnapshot(flows), weights)
+		score := exitScore(exitMetricsSnapshot(flows), weights) - candidates[i].reentryPenalty(reentryRamp)
 		if lessLoadedTieBreak(bestScore, score, bestFlows, flows, hysteresisPct) {
 			bestIndex, bestScore, bestFlows = i, score, flows
 		}
@@ -9213,6 +9236,16 @@ type multiClientChannel struct {
 	quarantineLiftTime        time.Time
 	quarantineLiftConnectSeen bool
 
+	// quarantineReconvictions counts this channel's completed bench-then-lift
+	// cycles: 0 through its first-ever bench, incremented on every lift (see
+	// clearQuarantineWithLock). Feeds benchDuration so a channel that keeps
+	// re-earning a bench holds it longer each time (RFC 2439-style flap
+	// damping) instead of the constant hold every episode got before this
+	// task. Deliberately session-scoped and never persisted or decayed --
+	// same lifetime as quarantineMigrated and the rest of the episode
+	// bookkeeping beside it, not new durable state. Guarded by stateLock.
+	quarantineReconvictions int
+
 	// pendingSendTime is when the current run of unacked sends began, reset on
 	// every ack. With sendNackCount > 0 it is the age of the oldest unmade
 	// progress, which is what sendStalled tests. Guarded by stateLock.
@@ -9767,6 +9800,11 @@ func (self *multiClientChannel) clearQuarantineWithLock() {
 		self.survivedQuarantine = true
 		self.quarantineLiftTime = time.Now()
 		self.quarantineLiftConnectSeen = false
+		// this episode is now a completed cycle, so the NEXT bench (if any)
+		// escalates one step; see quarantineReconvictions and benchDuration.
+		// A no-op lift (already clear, the branch above did not run) must not
+		// count -- there was no episode to have completed.
+		self.quarantineReconvictions++
 	}
 	self.quarantined = false
 	self.quarantineReason = blackholeNone
@@ -9828,6 +9866,45 @@ func (self *multiClientChannel) quarantineState() (blackholeReason, time.Time) {
 		return blackholeNone, time.Time{}
 	}
 	return self.quarantineReason, self.quarantineStart
+}
+
+// quarantineReconvictionCount reads the completed bench-then-lift cycle
+// count benchDuration escalates on; see the field comment.
+func (self *multiClientChannel) quarantineReconvictionCount() int {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+	return self.quarantineReconvictions
+}
+
+// quarantineReentryElapsed reports how long it has been since this channel's
+// most recent quarantine lift, and whether a lift has ever been recorded at
+// all -- ok is false for a channel that has never been quarantined, which
+// must read as "no ramp applies" rather than as a zero (== just-released)
+// elapsed. Reuses quarantineLiftTime, the same stamp the survived-quarantine
+// effectiveTier memory already reads, so the re-entry ramp adds no new
+// persistent state of its own.
+func (self *multiClientChannel) quarantineReentryElapsed(now time.Time) (time.Duration, bool) {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+	if self.quarantineLiftTime.IsZero() {
+		return 0, false
+	}
+	return now.Sub(self.quarantineLiftTime), true
+}
+
+// reentryPenalty is the scored-placement convenience wrapper around
+// reentryScorePenalty: 0 when ramp is disabled (QuarantineReentryRamp's
+// zero-value-off) or this channel has never been quarantined, else the
+// current point on the decay curve since its last lift.
+func (self *multiClientChannel) reentryPenalty(ramp time.Duration) float64 {
+	if ramp <= 0 {
+		return 0
+	}
+	elapsed, ok := self.quarantineReentryElapsed(time.Now())
+	if !ok {
+		return 0
+	}
+	return reentryScorePenalty(elapsed, ramp)
 }
 
 // hasOutstandingSends reports whether this channel currently holds sends that
@@ -11206,6 +11283,70 @@ const (
 	verdictActionExecuteExpired verdictActionKind = 3
 )
 
+// benchDuration is the RFC 2439-style flap-damping schedule for how long a
+// quarantine holds before the expiry escape (verdictActionExecuteExpired,
+// below) may act on it. dampening off returns base unconditionally -- the
+// constant StatsWindowKeepUnhealthyDuration hold every episode got before
+// this task, and what QuarantineDampening's zero value preserves exactly.
+// dampening on escalates 60s -> 120s -> 240s by reconvictions (this
+// channel's count of prior completed bench-then-lift cycles, see
+// quarantineReconvictionCount), capped at the third step: real field
+// evidence showed the SAME exits bench/lift 4-5 times in 10-20 minutes with
+// zero effect from bench migration (movable=0 on all 20 attempts) -- the
+// escalation exists to make repeat churn cost more without holding a
+// genuinely-recovered exit's bench open indefinitely. base is accepted but
+// ignored when dampening is on: the schedule is fixed by the literature, not
+// tunable per-deployment through the pre-existing knob. Pure: no clock
+// reads, no locks.
+func benchDuration(reconvictions int, base time.Duration, dampening bool) time.Duration {
+	if !dampening {
+		return base
+	}
+	steps := []time.Duration{60 * time.Second, 120 * time.Second, 240 * time.Second}
+	i := reconvictions
+	if i < 0 {
+		i = 0
+	}
+	if i >= len(steps) {
+		i = len(steps) - 1
+	}
+	return steps[i]
+}
+
+// reentryPenaltyWeight is the ceiling of the re-entry ramp's score
+// subtraction, at the instant a quarantine lifts (elapsed==0). exitScore's
+// own stall term alone can already cost up to 3.0 (see exitScore's
+// stallPenalty cap), so 1.0 is a meaningful push against a freshly released
+// exit without being able to outweigh a genuinely large health gap on its
+// own -- a just-lifted exit can still win if it is clearly the best
+// candidate, it just does not win a close tie-break on the strength of a
+// lift that happened a second ago.
+const reentryPenaltyWeight = 1.0
+
+// reentryScorePenalty is the asymmetric-re-entry half of the flap-damping
+// pair: a released exit does not return to full scored-placement standing
+// the instant its quarantine lifts (fast to leave selection, slow to return
+// to it in full), it returns at reduced weight that decays LINEARLY to zero
+// once `ramp` has elapsed since the lift. ramp<=0 disables the ramp entirely
+// (returns 0 for any input), which is QuarantineReentryRamp's zero-value-off
+// contract -- the legacy, pre-this-task behavior, where a lifted quarantine
+// carries no score penalty at all. elapsed<0 is clamped to 0 (full penalty)
+// rather than read as "already decayed" -- a caller passing a negative
+// elapsed has a clock problem, not evidence of a longer-than-possible clean
+// interval. This is a temporary SCORE adjustment only: it never touches
+// quarantined/warning state, membership, or which exits are convicted --
+// see reentryPenalty, its only caller, and scoredPlacementReorder, its
+// only consumer. Pure: no clock reads, no locks.
+func reentryScorePenalty(elapsed time.Duration, ramp time.Duration) float64 {
+	if ramp <= 0 || elapsed >= ramp {
+		return 0
+	}
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return reentryPenaltyWeight * float64(ramp-elapsed) / float64(ramp)
+}
+
 // verdictAction decides between executing, quarantining, and expiring a
 // blackhole verdict. The core invariant it encodes: an exit carrying live
 // flows may only be closed on hard evidence. Of the verdicts that reach here,
@@ -11468,13 +11609,23 @@ func (self *multiClientChannel) detectBlackhole() {
 				if quarantineReason, quarantineStart := self.quarantineState(); quarantineReason == reason {
 					quarantinedSince = quarantineStart
 				}
+				// the bench hold time: benchDuration(reconvictions, base,
+				// dampening off) returns base unchanged, so with
+				// QuarantineDampening at its zero value this is byte-for-byte
+				// self.settings.StatsWindowKeepUnhealthyDuration, exactly as
+				// it was passed directly before this task.
+				quarantineExpiry := benchDuration(
+					self.quarantineReconvictionCount(),
+					self.settings.StatsWindowKeepUnhealthyDuration,
+					self.reliabilitySettings().QuarantineDampening,
+				)
 				action := verdictAction(
 					reason,
 					self.reliabilitySettings().SoftVerdictDemote,
 					flowCount,
 					quarantinedSince,
 					now,
-					self.settings.StatsWindowKeepUnhealthyDuration,
+					quarantineExpiry,
 					self.emptiedByMigration(),
 				)
 

--- a/routing_class.go
+++ b/routing_class.go
@@ -1,0 +1,58 @@
+package connect
+
+// TrafficClass is the smart-routing traffic class of a flow. ClassUnknown is
+// the zero value on purpose: an un-classified flow (no classifier installed, or
+// classification not yet decided) is Unknown, which every scoring path treats
+// as "no class preference" so the layer is inert until a classifier is present.
+type TrafficClass uint8
+
+const (
+	ClassUnknown TrafficClass = iota
+	ClassLatency
+	ClassStreaming
+	ClassBulk
+	ClassBrowsing
+	ClassBackground
+)
+
+func (c TrafficClass) String() string {
+	switch c {
+	case ClassLatency:
+		return "latency"
+	case ClassStreaming:
+		return "streaming"
+	case ClassBulk:
+		return "bulk"
+	case ClassBrowsing:
+		return "browsing"
+	case ClassBackground:
+		return "background"
+	default:
+		return "unknown"
+	}
+}
+
+// FlowClass is a classification result: the class, the owning app (may be ""),
+// and a 0-100 confidence.
+type FlowClass struct {
+	Class      TrafficClass
+	AppId      string
+	Confidence uint8
+}
+
+// FlowClassifier turns a flow into a FlowClass. The nil implementation is the
+// legacy path; a real one (nDPI, a later phase) is installed via
+// SetFlowClassifier. Implementations must be safe for concurrent calls and must
+// not block (see classifyOrUnknown callers on the placement path).
+type FlowClassifier interface {
+	Classify(ipPath *IpPath, appId string) FlowClass
+}
+
+// classifyOrUnknown is the one-branch nil guard the placement path pays when no
+// classifier is installed, mirroring the flowOwnerFunc nil check.
+func classifyOrUnknown(c FlowClassifier, ipPath *IpPath, appId string) FlowClass {
+	if c == nil {
+		return FlowClass{Class: ClassUnknown, AppId: appId}
+	}
+	return c.Classify(ipPath, appId)
+}

--- a/routing_class_test.go
+++ b/routing_class_test.go
@@ -1,0 +1,20 @@
+package connect
+
+import "testing"
+
+func TestClassifyOrUnknownNilClassifier(t *testing.T) {
+	got := classifyOrUnknown(nil, &IpPath{}, "chrome.exe")
+	if got.Class != ClassUnknown {
+		t.Fatalf("nil classifier: class=%v want ClassUnknown", got.Class)
+	}
+	if got.AppId != "chrome.exe" {
+		t.Fatalf("nil classifier dropped appId: %q", got.AppId)
+	}
+}
+
+func TestTrafficClassZeroValueIsUnknown(t *testing.T) {
+	var z TrafficClass
+	if z != ClassUnknown || z.String() != "unknown" {
+		t.Fatalf("zero value must be unknown, got %v/%q", z, z.String())
+	}
+}

--- a/routing_placement_test.go
+++ b/routing_placement_test.go
@@ -1,0 +1,156 @@
+package connect
+
+import "testing"
+
+// panicClassifier proves the gate short-circuits: if the placement path ever
+// reaches Classify while ScoredPlacement is off, this panics the test rather
+// than silently passing.
+type panicClassifier struct{}
+
+func (panicClassifier) Classify(*IpPath, string) FlowClass {
+	panic("must not be called when gated off")
+}
+
+// fixedClassifier always names the same class, for the tests that need the
+// scoring path to actually run (class != ClassUnknown).
+type fixedClassifier struct{ class TrafficClass }
+
+func (f fixedClassifier) Classify(*IpPath, string) FlowClass {
+	return FlowClass{Class: f.class}
+}
+
+// TestScoredPlacementGatedOff is the brief's gate test: with ScoredPlacement
+// false -- the default, and what every current build and both live beta
+// testers run -- SetFlowClassifier installs the classifier (the seam works)
+// but nothing on the placement path may call it. There is no
+// newBareMultiClientForTest in this package; the suite's own bare-fixture
+// convention (a literal &RemoteUserNatMultiClient{}, e.g. flowCapTestParent
+// in ip_remote_multi_client_flow_cap_test.go, ip_remote_multi_client_test.go)
+// is reused here instead of inventing a new constructor.
+func TestScoredPlacementGatedOff(t *testing.T) {
+	c := &panicClassifier{}
+	client := &RemoteUserNatMultiClient{}
+	client.SetFlowClassifier(c)
+
+	// the seam: installed regardless of the gate
+	if client.flowClassifier.Load() == nil {
+		t.Fatal("classifier should be stored")
+	}
+	// the gate: off by default
+	if scoredPlacementEnabled(client.reliabilitySettings()) {
+		t.Fatal("scored placement must be off by default")
+	}
+}
+
+// TestSetFlowClassifierNilClears mirrors SetFlowOwnerLookup's nil-clears
+// contract (ip_remote_multi_client.go:SetFlowOwnerLookup): installing nil
+// removes a previously installed classifier.
+func TestSetFlowClassifierNilClears(t *testing.T) {
+	client := &RemoteUserNatMultiClient{}
+	client.SetFlowClassifier(panicClassifier{})
+	if client.flowClassifier.Load() == nil {
+		t.Fatal("classifier should be stored")
+	}
+
+	client.SetFlowClassifier(nil)
+	if client.flowClassifier.Load() != nil {
+		t.Fatal("nil must clear the classifier")
+	}
+}
+
+// TestScoredPlacementReorderClassUnknownIsNoop pins the safety property that
+// makes ScoredPlacement=true a no-op today: no FlowClassifier implementation
+// exists yet (SetFlowClassifier is the seam a later phase wires), so
+// classifyOrUnknown's nil-safe path always names ClassUnknown, and
+// scoredPlacementReorder must return the candidate list completely
+// untouched -- there is nothing to score against.
+func TestScoredPlacementReorderClassUnknownIsNoop(t *testing.T) {
+	parent, clients := flowCapTestParent(t, 0, 5, 1)
+	ipPath := &IpPath{Version: 4, Protocol: IpProtocolTcp}
+
+	got := parent.scoredPlacementReorder(clients, ipPath, "")
+	if len(got) != 2 || got[0] != clients[0] || got[1] != clients[1] {
+		t.Fatal("ClassUnknown (no classifier installed) must leave candidate order untouched")
+	}
+}
+
+// TestScoredPlacementReorderSingleCandidateIsNoop: nothing to reorder with
+// fewer than two candidates, so the classifier must not even be consulted --
+// a panic classifier here would fail the test if it were.
+func TestScoredPlacementReorderSingleCandidateIsNoop(t *testing.T) {
+	parent, clients := flowCapTestParent(t, 0, 5)
+	parent.SetFlowClassifier(panicClassifier{})
+	ipPath := &IpPath{Version: 4, Protocol: IpProtocolTcp}
+
+	got := parent.scoredPlacementReorder(clients, ipPath, "")
+	if len(got) != 1 || got[0] != clients[0] {
+		t.Fatal("a single candidate must pass through untouched, and without consulting the classifier")
+	}
+}
+
+// TestScoredPlacementReorderPrefersLessLoadedForClassifiedFlow exercises the
+// real scoring path end to end with a classifier installed. No per-exit RTT/
+// goodput/jitter/stall telemetry is wired yet (see exitMetricsSnapshot's
+// doc), so every candidate's exitScore is identical except for Flows, and a
+// classified flow must reduce to the less-loaded tie-break: the lighter
+// exit is promoted to the front.
+func TestScoredPlacementReorderPrefersLessLoadedForClassifiedFlow(t *testing.T) {
+	// clients[0] carries 50 flows, clients[1] carries 1
+	parent, clients := flowCapTestParent(t, 0, 50, 1)
+	parent.SetFlowClassifier(fixedClassifier{class: ClassBulk})
+	ipPath := &IpPath{Version: 4, Protocol: IpProtocolTcp}
+
+	got := parent.scoredPlacementReorder(clients, ipPath, "")
+	if len(got) != 2 || got[0] != clients[1] || got[1] != clients[0] {
+		t.Fatalf("classified flow with no telemetry differences must promote the less-loaded exit to the front")
+	}
+}
+
+// TestScoredPlacementReorderLeavesMembershipUnchanged pins the hard
+// constraint: the learner never overrides the safety layer. Reordering must
+// never add or drop a candidate -- raceCandidates already decided membership
+// via the verdict/quarantine/tier/flow-cap gates -- only permute the order.
+func TestScoredPlacementReorderLeavesMembershipUnchanged(t *testing.T) {
+	parent, clients := flowCapTestParent(t, 0, 3, 7, 1)
+	parent.SetFlowClassifier(fixedClassifier{class: ClassLatency})
+	ipPath := &IpPath{Version: 4, Protocol: IpProtocolTcp}
+
+	got := parent.scoredPlacementReorder(clients, ipPath, "")
+	if len(got) != len(clients) {
+		t.Fatalf("got %d candidates, want %d: reordering must never change membership", len(got), len(clients))
+	}
+	seen := map[*multiClientChannel]bool{}
+	for _, c := range got {
+		seen[c] = true
+	}
+	for _, c := range clients {
+		if !seen[c] {
+			t.Fatal("a candidate went missing across reordering")
+		}
+	}
+}
+
+// TestScoredPlacementGateBitesInPractice is the brief's "prove the gate
+// bites" check made permanent: scoredPlacementReorder is the function the
+// guarded branch in sendPacket's coalesceOrderedClients calls ONLY when
+// scoredPlacementEnabled is true. Calling it directly -- as if the gate were
+// open -- with a classifier that panics and two candidates to score proves
+// the classifier really is on the other side of that gate, not just absent
+// from a fixture that happens not to reach it.
+//
+// This is the same property manually verified while writing this test: with
+// scoredPlacementEnabled temporarily hardcoded to `return true`,
+// TestScoredPlacementGatedOff fails (its own direct assertion on the gate
+// value catches the flip) -- see the Task 8 report for both outputs.
+func TestScoredPlacementGateBitesInPractice(t *testing.T) {
+	parent, clients := flowCapTestParent(t, 0, 5, 1)
+	parent.SetFlowClassifier(panicClassifier{})
+	ipPath := &IpPath{Version: 4, Protocol: IpProtocolTcp}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected the panic classifier to fire when placement actually scores candidates")
+		}
+	}()
+	parent.scoredPlacementReorder(clients, ipPath, "")
+}

--- a/routing_priors.go
+++ b/routing_priors.go
@@ -1,0 +1,94 @@
+package connect
+
+import "sync"
+
+// ProviderPrior is the coarse, persistable memory of one provider IDENTITY
+// (never an exit instance): a smoothed score, a conviction count, and a
+// last-seen stamp. This is all that survives a restart — never raw learner
+// windows, which are stale-on-load at our churn and a poisoning surface.
+type ProviderPrior struct {
+	ScoreEwma    float64
+	Convictions  int
+	LastSeenUnix int64
+}
+
+type ProviderPriors struct {
+	mu sync.Mutex
+	m  map[string]ProviderPrior
+}
+
+func NewProviderPriors() *ProviderPriors {
+	return &ProviderPriors{m: map[string]ProviderPrior{}}
+}
+
+const priorsEwmaAlpha = 0.2
+
+func (p *ProviderPriors) Observe(providerId string, score float64, nowUnix int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pr := p.m[providerId]
+	if pr.LastSeenUnix == 0 {
+		pr.ScoreEwma = score
+	} else {
+		pr.ScoreEwma = priorsEwmaAlpha*score + (1-priorsEwmaAlpha)*pr.ScoreEwma
+	}
+	pr.LastSeenUnix = nowUnix
+	p.m[providerId] = pr
+}
+
+func (p *ProviderPriors) Convict(providerId string, nowUnix int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pr := p.m[providerId]
+	pr.Convictions++
+	pr.LastSeenUnix = nowUnix
+	p.m[providerId] = pr
+}
+
+// Bias returns a recruitment bias in [0,1]; unknown providers are neutral 0.5.
+// A conviction history subtracts; the score EWMA is the base. Staleness decay is
+// applied by the caller passing a recent nowUnix into DecayedBias if needed; the
+// base Bias is time-independent for testability.
+func (p *ProviderPriors) Bias(providerId string) float64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	pr, ok := p.m[providerId]
+	if !ok {
+		return 0.5
+	}
+	b := pr.ScoreEwma - 0.15*float64(pr.Convictions)
+	if b < 0 {
+		b = 0
+	}
+	if b > 1 {
+		b = 1
+	}
+	return b
+}
+
+func (p *ProviderPriors) Snapshot() map[string]ProviderPrior {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make(map[string]ProviderPrior, len(p.m))
+	for k, v := range p.m {
+		out[k] = v
+	}
+	return out
+}
+
+func (p *ProviderPriors) Load(m map[string]ProviderPrior) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.m = make(map[string]ProviderPrior, len(m))
+	for k, v := range m {
+		p.m[k] = v
+	}
+}
+
+// PriorsStore is the persistence seam; the sdk supplies a LocalState-backed
+// implementation. A nil store means in-memory only (bare fixtures, mobile before
+// wiring). Retention/TTL is enforced by the store on load, not here.
+type PriorsStore interface {
+	Load() map[string]ProviderPrior
+	Save(map[string]ProviderPrior) error
+}

--- a/routing_priors.go
+++ b/routing_priors.go
@@ -26,8 +26,8 @@ const priorsEwmaAlpha = 0.2
 func (p *ProviderPriors) Observe(providerId string, score float64, nowUnix int64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	pr := p.m[providerId]
-	if pr.LastSeenUnix == 0 {
+	pr, ok := p.m[providerId]
+	if !ok {
 		pr.ScoreEwma = score
 	} else {
 		pr.ScoreEwma = priorsEwmaAlpha*score + (1-priorsEwmaAlpha)*pr.ScoreEwma
@@ -39,16 +39,20 @@ func (p *ProviderPriors) Observe(providerId string, score float64, nowUnix int64
 func (p *ProviderPriors) Convict(providerId string, nowUnix int64) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	pr := p.m[providerId]
+	pr, ok := p.m[providerId]
+	if !ok {
+		// Only convict providers we have already observed; presence-keyed like Observe.
+		return
+	}
 	pr.Convictions++
 	pr.LastSeenUnix = nowUnix
 	p.m[providerId] = pr
 }
 
 // Bias returns a recruitment bias in [0,1]; unknown providers are neutral 0.5.
-// A conviction history subtracts; the score EWMA is the base. Staleness decay is
-// applied by the caller passing a recent nowUnix into DecayedBias if needed; the
-// base Bias is time-independent for testability.
+// A conviction history subtracts; the score EWMA is the base. The Bias method is
+// deliberately time-independent for testability; staleness and TTL are enforced by
+// the persistence layer in a later task.
 func (p *ProviderPriors) Bias(providerId string) float64 {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/routing_priors.go
+++ b/routing_priors.go
@@ -41,8 +41,10 @@ func (p *ProviderPriors) Convict(providerId string, nowUnix int64) {
 	defer p.mu.Unlock()
 	pr, ok := p.m[providerId]
 	if !ok {
-		// Only convict providers we have already observed; presence-keyed like Observe.
-		return
+		// Convict on absent id: create entry with neutral base so conviction penalty applies.
+		// Conviction must never be dropped—even pre-observe convictions (e.g., vetting failures)
+		// must degrade the provider from neutral 0.5 to below-neutral 0.35 (0.5 - 0.15*1).
+		pr.ScoreEwma = 0.5
 	}
 	pr.Convictions++
 	pr.LastSeenUnix = nowUnix

--- a/routing_priors_test.go
+++ b/routing_priors_test.go
@@ -1,0 +1,78 @@
+package connect
+
+import "testing"
+
+func TestProviderPriorsEwmaAndBias(t *testing.T) {
+	p := NewProviderPriors()
+	if p.Bias("unknown") != 0.5 {
+		t.Fatal("unknown provider must be neutral 0.5")
+	}
+	for i := 0; i < 20; i++ {
+		p.Observe("good", 0.9, 1000)
+	}
+	for i := 0; i < 20; i++ {
+		p.Observe("bad", 0.1, 1000)
+	}
+	if !(p.Bias("good") > p.Bias("bad")) {
+		t.Fatalf("good provider must bias higher: good=%f bad=%f", p.Bias("good"), p.Bias("bad"))
+	}
+}
+
+func TestProviderPriorsConvictionLowersBias(t *testing.T) {
+	p := NewProviderPriors()
+	for i := 0; i < 20; i++ {
+		p.Observe("x", 0.9, 1000)
+	}
+	before := p.Bias("x")
+	p.Convict("x", 1000)
+	p.Convict("x", 1000)
+	if !(p.Bias("x") < before) {
+		t.Fatal("convictions must lower recruitment bias")
+	}
+}
+
+func TestProviderPriorsRoundTrip(t *testing.T) {
+	p := NewProviderPriors()
+	p.Observe("a", 0.7, 1234)
+	snap := p.Snapshot()
+	q := NewProviderPriors()
+	q.Load(snap)
+	if q.Snapshot()["a"].ScoreEwma != snap["a"].ScoreEwma {
+		t.Fatal("round-trip must preserve EWMA")
+	}
+}
+
+func TestProviderPriorsSnapshotIsCopy(t *testing.T) {
+	p := NewProviderPriors()
+	p.Observe("a", 0.7, 1234)
+	snap := p.Snapshot()
+	// Mutate the returned snapshot
+	snap["a"] = ProviderPrior{ScoreEwma: 0.1, Convictions: 99, LastSeenUnix: 9999}
+	snap["b"] = ProviderPrior{ScoreEwma: 0.5, Convictions: 1, LastSeenUnix: 1000}
+	// Internal state should be unchanged
+	if p.Bias("a") != 0.7 {
+		t.Fatalf("Snapshot() did not return a copy; internal state was mutated")
+	}
+	if p.Bias("b") != 0.5 {
+		t.Fatalf("Snapshot() did not return a copy; unrelated key was added to internal state")
+	}
+}
+
+func TestProviderPriorsLoadCopiesIn(t *testing.T) {
+	data := map[string]ProviderPrior{
+		"x": {ScoreEwma: 0.8, Convictions: 1, LastSeenUnix: 5000},
+	}
+	p := NewProviderPriors()
+	p.Load(data)
+	// Mutate the original map
+	data["x"] = ProviderPrior{ScoreEwma: 0.2, Convictions: 99, LastSeenUnix: 9999}
+	data["y"] = ProviderPrior{ScoreEwma: 0.5, Convictions: 0, LastSeenUnix: 1000}
+	// Check the snapshot to verify internal state is unchanged
+	snap := p.Snapshot()
+	if snap["x"].ScoreEwma != 0.8 || snap["x"].Convictions != 1 {
+		t.Fatalf("Load() did not copy in; internal state was changed by mutating caller's map")
+	}
+	if _, ok := snap["y"]; ok {
+		t.Fatalf("Load() did not copy in; unrelated key from mutated map appeared in internal state")
+	}
+}

--- a/routing_priors_test.go
+++ b/routing_priors_test.go
@@ -77,14 +77,25 @@ func TestProviderPriorsLoadCopiesIn(t *testing.T) {
 	}
 }
 
-func TestProviderPriorsConvictThenObserveSeedsValue(t *testing.T) {
+func TestProviderPriorsConvictThenObserveBlends(t *testing.T) {
 	p := NewProviderPriors()
-	// Convict before first Observe — presence-keyed seeding must seed ScoreEwma
+	// Convict before first Observe: creates entry with ScoreEwma=0.5, Convictions=1
 	p.Convict("x", 1000)
+	// Verify the conviction is recorded and Bias is penalized < 0.5
+	biasAfterConvict := p.Bias("x")
+	if biasAfterConvict != 0.35 {
+		t.Fatalf("Bias after single convict on never-observed provider must be 0.35, got %f", biasAfterConvict)
+	}
+	// First Observe after Convict should BLEND (entry exists), not reseed
+	// 0.2*0.9 + 0.8*0.5 = 0.18 + 0.4 = 0.58
 	p.Observe("x", 0.9, 1001)
 	snap := p.Snapshot()
-	if snap["x"].ScoreEwma != 0.9 {
-		t.Fatalf("Convict-then-Observe should seed to score 0.9, got %f", snap["x"].ScoreEwma)
+	want := 0.58
+	if snap["x"].ScoreEwma < want-0.0001 || snap["x"].ScoreEwma > want+0.0001 {
+		t.Fatalf("Convict-then-Observe should blend 0.58, not reseed; got %f", snap["x"].ScoreEwma)
+	}
+	if snap["x"].Convictions != 1 {
+		t.Fatalf("Convictions must remain 1 after Observe; got %d", snap["x"].Convictions)
 	}
 }
 

--- a/routing_priors_test.go
+++ b/routing_priors_test.go
@@ -76,3 +76,44 @@ func TestProviderPriorsLoadCopiesIn(t *testing.T) {
 		t.Fatalf("Load() did not copy in; unrelated key from mutated map appeared in internal state")
 	}
 }
+
+func TestProviderPriorsConvictThenObserveSeedsValue(t *testing.T) {
+	p := NewProviderPriors()
+	// Convict before first Observe — presence-keyed seeding must seed ScoreEwma
+	p.Convict("x", 1000)
+	p.Observe("x", 0.9, 1001)
+	snap := p.Snapshot()
+	if snap["x"].ScoreEwma != 0.9 {
+		t.Fatalf("Convict-then-Observe should seed to score 0.9, got %f", snap["x"].ScoreEwma)
+	}
+}
+
+func TestProviderPriorsBiasClampedToZero(t *testing.T) {
+	p := NewProviderPriors()
+	// Seed a provider with high score, then add enough convictions to go negative
+	p.Observe("x", 0.9, 1000)
+	// 7 convictions: 0.9 - 0.15*7 = 0.9 - 1.05 = -0.15 (negative)
+	for i := 0; i < 7; i++ {
+		p.Convict("x", 1000)
+	}
+	bias := p.Bias("x")
+	if bias != 0.0 {
+		t.Fatalf("Bias with negative raw value must clamp to 0.0, got %f", bias)
+	}
+}
+
+func TestProviderPriorsPresenceKeyedSeeding(t *testing.T) {
+	p := NewProviderPriors()
+	// Observe multiple times with nowUnix=0 (fixture time, or "time unknown").
+	// With presence-keyed seeding, all observations after the first should blend.
+	// With timestamp-based seeding (pr.LastSeenUnix == 0), every observation would re-seed,
+	// defeating EWMA smoothing and allowing a single malicious sample to persist.
+	p.Observe("x", 0.9, 0) // Seeds to 0.9, LastSeenUnix=0
+	p.Observe("x", 0.1, 0) // Should blend to 0.2*0.1 + 0.8*0.9 = 0.74
+	// If using timestamp seeding, this would have re-seeded to 0.1 instead.
+	snap := p.Snapshot()
+	want := 0.74
+	if snap["x"].ScoreEwma < want-0.0001 || snap["x"].ScoreEwma > want+0.0001 {
+		t.Fatalf("Observe with nowUnix=0 must blend, not re-seed: got %f, want %f", snap["x"].ScoreEwma, want)
+	}
+}

--- a/routing_quarantine_test.go
+++ b/routing_quarantine_test.go
@@ -237,29 +237,38 @@ func TestReentryPenaltyAppliesJustAfterALift(t *testing.T) {
 
 // TestQuarantineExpiryShortCircuitsReconvictionLookup is fix-round-1's
 // required proof: quarantineReconvictionCount() takes stateLock, and
-// benchDuration is called as a plain function -- Go evaluates every
-// argument expression before the call, so passing
-// self.quarantineReconvictionCount() directly as an argument (the original
-// shape) took the lock on every blackhole-branch pass even when
-// QuarantineDampening was false and benchDuration immediately discarded the
-// value. The fix moves the knob check before the lookup entirely, so the
-// lock is never taken on the off path.
+// benchDuration is called as a plain function -- Go evaluates every argument
+// expression before the call, so passing self.quarantineReconvictionCount()
+// directly as an argument (the original shape) took the lock on every
+// blackhole-branch pass even when QuarantineDampening was false and
+// benchDuration immediately discarded the value. The fix moves the knob
+// check before the lookup entirely, so the lock is never taken on the off
+// path.
 //
 // This is a STRUCTURAL test, not a call-counting one: quarantineReconvictionCount
 // has no seam to count real lock acquisitions without adding call-counting
 // instrumentation to production code purely to make this testable, which is
-// explicitly out of scope for this fix. Instead it asserts the source
-// structure the short-circuit depends on:
-//  1. the off-path default is assigned from self.settings.StatsWindowKeepUnhealthyDuration
-//     BEFORE the dampening guard, so an unguarded read never sees anything else;
-//  2. quarantineReconvictionCount() is called exactly once in detectBlackhole;
-//  3. that one call sits exactly one indent level inside an `if dampening { ... }`
-//     guard (not before it, not unconditionally) -- so it is unreachable by
-//     construction whenever dampening is false.
+// out of scope. It protects exactly one property -- the reconviction lookup
+// is unreachable when the knob is off -- via three checks:
+//  1. quarantineReconvictionCount() is called exactly once in detectBlackhole;
+//  2. that one call sits somewhere inside an enclosing `if` whose condition
+//     mentions QuarantineDampening, with nothing closing that block before
+//     reaching the call;
+//  3. the off-path default is assigned from
+//     self.settings.StatsWindowKeepUnhealthyDuration strictly before that
+//     guard, so an unguarded read never sees anything else.
+//
+// It deliberately does NOT assert the guard's exact text, that the guard is
+// the line immediately before the call, or an exact indentation delta --
+// fix-round-1's first version of this test pinned all three, and detectBlackhole
+// is a demonstrated hotspot (tasks 7, 8, 9 and this fix have all touched it
+// in quick succession); a benign rename, an `if x := f(); x` simplified to
+// `if f()`, or a wrapped block would have failed a perfectly correct change.
+// Do not "tighten" this back to exact-text/adjacency/indent-delta matching.
 //
 // This test was verified against the pre-fix shape (self.quarantineReconvictionCount()
 // passed directly as benchDuration's first argument, unconditionally) and
-// fails there as expected -- see the task-9 report's fix-round-1 section for
+// fails there as expected -- see the task-9 report's fix-round-2 section for
 // the captured failing output.
 func TestQuarantineExpiryShortCircuitsReconvictionLookup(t *testing.T) {
 	source, err := readSource("ip_remote_multi_client.go")
@@ -270,24 +279,15 @@ func TestQuarantineExpiryShortCircuitsReconvictionLookup(t *testing.T) {
 	if !ok {
 		t.Fatal("could not find detectBlackhole")
 	}
-
-	defaultIdx := strings.Index(body, "quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration")
-	if defaultIdx < 0 {
-		t.Fatal("the off-path default (quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration) is missing")
-	}
-	guardIdx := strings.Index(body, "if dampening := self.reliabilitySettings().QuarantineDampening; dampening {")
-	if guardIdx < 0 {
-		t.Fatal("the dampening short-circuit guard is missing or its shape changed")
-	}
-	if guardIdx < defaultIdx {
-		t.Fatal("the dampening guard must come AFTER the off-path default is assigned, or the default is not really the off-path value")
+	lines := strings.Split(body, "\n")
+	indentOf := func(s string) int {
+		return len(s) - len(strings.TrimLeft(s, "\t"))
 	}
 
 	if n := strings.Count(body, "self.quarantineReconvictionCount()"); n != 1 {
 		t.Fatalf("expected exactly one call to quarantineReconvictionCount in detectBlackhole, found %d", n)
 	}
 
-	lines := strings.Split(body, "\n")
 	callLine := -1
 	for i, line := range lines {
 		if strings.Contains(line, "self.quarantineReconvictionCount()") {
@@ -295,19 +295,49 @@ func TestQuarantineExpiryShortCircuitsReconvictionLookup(t *testing.T) {
 			break
 		}
 	}
-	if callLine <= 0 {
+	if callLine < 0 {
 		t.Fatal("could not locate the quarantineReconvictionCount call line")
 	}
 
-	guardLine := lines[callLine-1]
-	if !strings.Contains(guardLine, "QuarantineDampening") || !strings.Contains(guardLine, "dampening") ||
-		!strings.HasSuffix(strings.TrimRight(guardLine, " \t"), "{") {
-		t.Fatalf("quarantineReconvictionCount is not directly nested under an `if dampening` guard: preceding line is %q", guardLine)
+	// walk backward from the call, tracking the innermost enclosing scope by
+	// indent: the first non-blank line at a strictly shallower indent than
+	// the current threshold is that scope's opening line. If it is not the
+	// dampening guard, treat it as the new threshold and keep walking
+	// outward -- this naturally requires nothing at or below a candidate
+	// guard's indent to intervene before the call, without hardcoding
+	// adjacency or an exact delta.
+	guardLine := -1
+	threshold := indentOf(lines[callLine])
+	for i := callLine - 1; 0 <= i; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
+		}
+		ind := indentOf(lines[i])
+		if threshold <= ind {
+			continue
+		}
+		if strings.Contains(trimmed, "if") && strings.Contains(trimmed, "QuarantineDampening") && strings.HasSuffix(trimmed, "{") {
+			guardLine = i
+			break
+		}
+		threshold = ind
+	}
+	if guardLine < 0 {
+		t.Fatal("quarantineReconvictionCount is not nested inside any enclosing `if ... QuarantineDampening ... {` guard")
 	}
 
-	guardIndent := len(guardLine) - len(strings.TrimLeft(guardLine, "\t"))
-	callIndent := len(lines[callLine]) - len(strings.TrimLeft(lines[callLine], "\t"))
-	if callIndent != guardIndent+1 {
-		t.Fatalf("quarantineReconvictionCount call is not exactly one indent level inside the dampening guard: guard indent=%d call indent=%d", guardIndent, callIndent)
+	defaultLine := -1
+	for i, line := range lines {
+		if strings.Contains(line, "quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration") {
+			defaultLine = i
+			break
+		}
+	}
+	if defaultLine < 0 {
+		t.Fatal("the off-path default (quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration) is missing")
+	}
+	if guardLine <= defaultLine {
+		t.Fatal("the dampening guard must come AFTER the off-path default is assigned, or the default is not really the off-path value")
 	}
 }

--- a/routing_quarantine_test.go
+++ b/routing_quarantine_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -231,5 +232,82 @@ func TestReentryPenaltyAppliesJustAfterALift(t *testing.T) {
 	got := client.reentryPenalty(45 * time.Second)
 	if got <= 0 || got > reentryPenaltyWeight {
 		t.Fatalf("a just-released exit must carry a positive penalty at or under the full weight, got %v", got)
+	}
+}
+
+// TestQuarantineExpiryShortCircuitsReconvictionLookup is fix-round-1's
+// required proof: quarantineReconvictionCount() takes stateLock, and
+// benchDuration is called as a plain function -- Go evaluates every
+// argument expression before the call, so passing
+// self.quarantineReconvictionCount() directly as an argument (the original
+// shape) took the lock on every blackhole-branch pass even when
+// QuarantineDampening was false and benchDuration immediately discarded the
+// value. The fix moves the knob check before the lookup entirely, so the
+// lock is never taken on the off path.
+//
+// This is a STRUCTURAL test, not a call-counting one: quarantineReconvictionCount
+// has no seam to count real lock acquisitions without adding call-counting
+// instrumentation to production code purely to make this testable, which is
+// explicitly out of scope for this fix. Instead it asserts the source
+// structure the short-circuit depends on:
+//  1. the off-path default is assigned from self.settings.StatsWindowKeepUnhealthyDuration
+//     BEFORE the dampening guard, so an unguarded read never sees anything else;
+//  2. quarantineReconvictionCount() is called exactly once in detectBlackhole;
+//  3. that one call sits exactly one indent level inside an `if dampening { ... }`
+//     guard (not before it, not unconditionally) -- so it is unreachable by
+//     construction whenever dampening is false.
+//
+// This test was verified against the pre-fix shape (self.quarantineReconvictionCount()
+// passed directly as benchDuration's first argument, unconditionally) and
+// fails there as expected -- see the task-9 report's fix-round-1 section for
+// the captured failing output.
+func TestQuarantineExpiryShortCircuitsReconvictionLookup(t *testing.T) {
+	source, err := readSource("ip_remote_multi_client.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, ok := functionBody(source, "func (self *multiClientChannel) detectBlackhole()")
+	if !ok {
+		t.Fatal("could not find detectBlackhole")
+	}
+
+	defaultIdx := strings.Index(body, "quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration")
+	if defaultIdx < 0 {
+		t.Fatal("the off-path default (quarantineExpiry := self.settings.StatsWindowKeepUnhealthyDuration) is missing")
+	}
+	guardIdx := strings.Index(body, "if dampening := self.reliabilitySettings().QuarantineDampening; dampening {")
+	if guardIdx < 0 {
+		t.Fatal("the dampening short-circuit guard is missing or its shape changed")
+	}
+	if guardIdx < defaultIdx {
+		t.Fatal("the dampening guard must come AFTER the off-path default is assigned, or the default is not really the off-path value")
+	}
+
+	if n := strings.Count(body, "self.quarantineReconvictionCount()"); n != 1 {
+		t.Fatalf("expected exactly one call to quarantineReconvictionCount in detectBlackhole, found %d", n)
+	}
+
+	lines := strings.Split(body, "\n")
+	callLine := -1
+	for i, line := range lines {
+		if strings.Contains(line, "self.quarantineReconvictionCount()") {
+			callLine = i
+			break
+		}
+	}
+	if callLine <= 0 {
+		t.Fatal("could not locate the quarantineReconvictionCount call line")
+	}
+
+	guardLine := lines[callLine-1]
+	if !strings.Contains(guardLine, "QuarantineDampening") || !strings.Contains(guardLine, "dampening") ||
+		!strings.HasSuffix(strings.TrimRight(guardLine, " \t"), "{") {
+		t.Fatalf("quarantineReconvictionCount is not directly nested under an `if dampening` guard: preceding line is %q", guardLine)
+	}
+
+	guardIndent := len(guardLine) - len(strings.TrimLeft(guardLine, "\t"))
+	callIndent := len(lines[callLine]) - len(strings.TrimLeft(lines[callLine], "\t"))
+	if callIndent != guardIndent+1 {
+		t.Fatalf("quarantineReconvictionCount call is not exactly one indent level inside the dampening guard: guard indent=%d call indent=%d", guardIndent, callIndent)
 	}
 }

--- a/routing_quarantine_test.go
+++ b/routing_quarantine_test.go
@@ -1,0 +1,235 @@
+package connect
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBenchDurationEscalates is the brief's own table: dampening off is a
+// constant base (today's behavior, unchanged), dampening on escalates
+// 60s -> 120s -> 240s by reconvictions and caps at the third step.
+func TestBenchDurationEscalates(t *testing.T) {
+	base := 60 * time.Second
+	if benchDuration(0, base, false) != base {
+		t.Fatal("dampening off must be constant base")
+	}
+	if benchDuration(0, base, true) != 60*time.Second ||
+		benchDuration(1, base, true) != 120*time.Second ||
+		benchDuration(2, base, true) != 240*time.Second ||
+		benchDuration(5, base, true) != 240*time.Second {
+		t.Fatal("dampening on must escalate 60->120->240 and cap")
+	}
+}
+
+// TestBenchDurationDampeningOffIgnoresReconvictions pins the other half of
+// the zero-value-off contract: with dampening off, base is returned no
+// matter how many times this exit has already been reconvicted. If a future
+// edit ever let reconvictions leak into the off path, this catches it before
+// it changes a default build's bench hold time.
+func TestBenchDurationDampeningOffIgnoresReconvictions(t *testing.T) {
+	base := 90 * time.Second
+	for _, reconvictions := range []int{0, 1, 2, 3, 100} {
+		if got := benchDuration(reconvictions, base, false); got != base {
+			t.Fatalf("dampening off at reconvictions=%d: got %v, want constant base %v", reconvictions, got, base)
+		}
+	}
+}
+
+// TestBenchDurationNegativeReconvictionsClamped guards the defensive clamp:
+// a corrupt or not-yet-incremented negative count must read as the first
+// tier, not panic on the steps slice or escalate backwards.
+func TestBenchDurationNegativeReconvictionsClamped(t *testing.T) {
+	base := 60 * time.Second
+	if got := benchDuration(-1, base, true); got != 60*time.Second {
+		t.Fatalf("negative reconvictions must clamp to the first tier: got %v", got)
+	}
+}
+
+// TestDefaultMultiClientSettingsQuarantineKnobsZeroValueOff pins the actual
+// regression risk: a default build must behave exactly like today. If a
+// future well-meaning edit ever sets one of these in
+// DefaultMultiClientSettings, this test catches it before it ships and
+// silently opts every default build into flap damping or the re-entry ramp.
+func TestDefaultMultiClientSettingsQuarantineKnobsZeroValueOff(t *testing.T) {
+	s := DefaultMultiClientSettings()
+	if s.QuarantineDampening {
+		t.Fatal("DefaultMultiClientSettings must leave QuarantineDampening off (false)")
+	}
+	if s.QuarantineReentryRamp != 0 {
+		t.Fatal("DefaultMultiClientSettings must leave QuarantineReentryRamp at 0")
+	}
+}
+
+// TestNewQuarantineKnobsZeroValueOff asserts QuarantineDampening and
+// QuarantineReentryRamp follow the same zero-value-off contract as every
+// other ReliabilitySettings field: a nil override (or one built from an
+// older struct) must leave them off, and ReliabilitySettingsFrom must
+// faithfully copy each through when it is set.
+//
+// The copy-fidelity half deliberately does NOT source its input from
+// DefaultMultiClientSettings(): the zero-value-off requirement means the
+// defaults leave both knobs at false/0, so a comparison built on the
+// defaults (got.X != s.X) is false != false regardless of whether
+// ReliabilitySettingsFrom copies the field at all -- deleting the copy line
+// entirely would still pass. Instead an explicit, fully-populated
+// MultiClientSettings is round-tripped, with distinct non-zero values (true
+// / 45s, not the same value twice) so a copy line wired to the wrong source
+// field is caught too, not just a missing one.
+func TestNewQuarantineKnobsZeroValueOff(t *testing.T) {
+	z := ReliabilitySettingsFrom(nil) // nil -> zero value
+	if z.QuarantineDampening || z.QuarantineReentryRamp != 0 {
+		t.Fatal("new quarantine knobs must be zero-value-off (legacy behavior)")
+	}
+
+	d := DefaultMultiClientSettings()
+	if d.QuarantineDampening || d.QuarantineReentryRamp != 0 {
+		t.Fatal("DefaultMultiClientSettings must leave the new quarantine knobs zero-value-off")
+	}
+
+	src := &MultiClientSettings{
+		QuarantineDampening:   true,
+		QuarantineReentryRamp: 45 * time.Second,
+	}
+	got := ReliabilitySettingsFrom(src)
+	if got.QuarantineDampening != true {
+		t.Fatal("ReliabilitySettingsFrom must copy QuarantineDampening")
+	}
+	if got.QuarantineReentryRamp != 45*time.Second {
+		t.Fatalf("ReliabilitySettingsFrom must copy QuarantineReentryRamp: got %v, want 45s", got.QuarantineReentryRamp)
+	}
+}
+
+// TestQuarantineReconvictionsEscalateAcrossLiftCycles is the counter
+// benchDuration reads: 0 through the first-ever bench, incremented on every
+// completed lift, and never incremented by a no-op clear on an already-clear
+// channel (which has no episode to have completed).
+func TestQuarantineReconvictionsEscalateAcrossLiftCycles(t *testing.T) {
+	client := stallTestChannel()
+
+	if got := client.quarantineReconvictionCount(); got != 0 {
+		t.Fatalf("a never-quarantined channel must read 0 reconvictions, got %d", got)
+	}
+
+	// a clear on an already-clear channel must not manufacture a reconviction
+	client.clearQuarantine()
+	if got := client.quarantineReconvictionCount(); got != 0 {
+		t.Fatalf("a no-op clear must not increment reconvictions, got %d", got)
+	}
+
+	client.setQuarantined(blackholeNoReceiveAck)
+	if got := client.quarantineReconvictionCount(); got != 0 {
+		t.Fatalf("reconvictions must not advance until the FIRST episode lifts, got %d", got)
+	}
+	client.clearQuarantine()
+	if got := client.quarantineReconvictionCount(); got != 1 {
+		t.Fatalf("the first lift must bring reconvictions to 1, got %d", got)
+	}
+
+	client.setQuarantined(blackholeNoReceiveSyn)
+	client.clearQuarantine()
+	if got := client.quarantineReconvictionCount(); got != 2 {
+		t.Fatalf("a second bench-then-lift cycle must bring reconvictions to 2, got %d", got)
+	}
+}
+
+// TestQuarantineReconvictionsSurviveReceiveProgressRelease proves the
+// counter feeding benchDuration is wired through the SAME release-on-
+// receive-progress path this task must not disturb: addReceiveAck's clear
+// still lifts the quarantine (unchanged), and it also advances the
+// reconviction count exactly like clearQuarantine does, since both route
+// through clearQuarantineWithLock.
+func TestQuarantineReconvictionsSurviveReceiveProgressRelease(t *testing.T) {
+	client := stallTestChannel()
+
+	client.setQuarantined(blackholeNoReceiveAck)
+	AssertEqual(t, client.isQuarantined(), true)
+
+	client.addReceiveAck(1440)
+
+	// the hard constraint: release-on-receive-progress still lifts the
+	// quarantine exactly as before this task
+	AssertEqual(t, client.isQuarantined(), false)
+	if got := client.quarantineReconvictionCount(); got != 1 {
+		t.Fatalf("a receive-progress release must still advance reconvictions, got %d", got)
+	}
+}
+
+// TestReentryScorePenaltyDecaysToZero is the pure decay curve: full weight
+// at the instant of release (elapsed==0), zero once ramp has fully elapsed,
+// and strictly decreasing in between. ramp<=0 is the zero-value-off legacy
+// path -- no penalty at all, for any elapsed.
+func TestReentryScorePenaltyDecaysToZero(t *testing.T) {
+	ramp := 100 * time.Second
+
+	if got := reentryScorePenalty(0, 0); got != 0 {
+		t.Fatalf("ramp<=0 must disable the penalty entirely, got %v", got)
+	}
+	if got := reentryScorePenalty(50*time.Second, 0); got != 0 {
+		t.Fatalf("ramp<=0 must disable the penalty regardless of elapsed, got %v", got)
+	}
+
+	atRelease := reentryScorePenalty(0, ramp)
+	if atRelease != reentryPenaltyWeight {
+		t.Fatalf("elapsed==0 must be the full penalty weight: got %v, want %v", atRelease, reentryPenaltyWeight)
+	}
+
+	half := reentryScorePenalty(50*time.Second, ramp)
+	if half <= 0 || half >= atRelease {
+		t.Fatalf("mid-ramp penalty must be strictly between 0 and the full weight, got %v", half)
+	}
+	if half != reentryPenaltyWeight*0.5 {
+		t.Fatalf("halfway through a linear ramp must be exactly half weight: got %v, want %v", half, reentryPenaltyWeight*0.5)
+	}
+
+	if got := reentryScorePenalty(ramp, ramp); got != 0 {
+		t.Fatalf("elapsed==ramp must have fully decayed to 0, got %v", got)
+	}
+	if got := reentryScorePenalty(2*ramp, ramp); got != 0 {
+		t.Fatalf("elapsed past ramp must stay at 0, got %v", got)
+	}
+
+	// a negative elapsed (clock trouble, not a longer-than-possible clean
+	// interval) clamps to the full penalty rather than reading as decayed
+	if got := reentryScorePenalty(-5*time.Second, ramp); got != atRelease {
+		t.Fatalf("negative elapsed must clamp to full penalty, got %v want %v", got, atRelease)
+	}
+}
+
+// TestReentryPenaltyZeroRampIsLegacyNoop is the channel-level zero-value-off
+// check: even a freshly-released channel (elapsed==0, the worst case for a
+// penalty) must read exactly 0 when QuarantineReentryRamp is at its zero
+// value, so a default build's scored placement is byte-for-byte unchanged.
+func TestReentryPenaltyZeroRampIsLegacyNoop(t *testing.T) {
+	client := stallTestChannel()
+	client.setQuarantined(blackholeNoReceiveAck)
+	client.clearQuarantine()
+
+	if got := client.reentryPenalty(0); got != 0 {
+		t.Fatalf("ramp==0 must be a no-op regardless of how recently the exit was released, got %v", got)
+	}
+}
+
+// TestReentryPenaltyRequiresAPriorLift: a channel that has never been
+// quarantined has no lift timestamp to measure from, and must not be
+// penalized just because a ramp is configured.
+func TestReentryPenaltyRequiresAPriorLift(t *testing.T) {
+	client := stallTestChannel()
+	if got := client.reentryPenalty(45 * time.Second); got != 0 {
+		t.Fatalf("a never-quarantined channel must carry no re-entry penalty, got %v", got)
+	}
+}
+
+// TestReentryPenaltyAppliesJustAfterALift: with a ramp configured, a channel
+// released moments ago must carry a strictly positive penalty close to the
+// full weight -- the asymmetric half of flap damping (fast to leave
+// selection via quarantine, slow to return to full standing).
+func TestReentryPenaltyAppliesJustAfterALift(t *testing.T) {
+	client := stallTestChannel()
+	client.setQuarantined(blackholeNoReceiveAck)
+	client.clearQuarantine()
+
+	got := client.reentryPenalty(45 * time.Second)
+	if got <= 0 || got > reentryPenaltyWeight {
+		t.Fatalf("a just-released exit must carry a positive penalty at or under the full weight, got %v", got)
+	}
+}

--- a/routing_reward.go
+++ b/routing_reward.go
@@ -1,0 +1,58 @@
+package connect
+
+import "fmt"
+
+// rewardAccumulator is the Phase 0 divergence gate: it records per-(class,exit)
+// outcomes so a field capture can answer "do per-class rankings actually
+// diverge" before any learner is built. Reward = class-normalized goodput +
+// stall-free fraction. It is measurement only — it changes NO placement.
+type rewardKey struct {
+	Class  TrafficClass
+	ExitId string
+}
+
+type rewardStat struct {
+	samples    int
+	goodputSum float64
+	stallFreeN int
+}
+
+type rewardAccumulator struct {
+	m map[rewardKey]*rewardStat
+}
+
+func newRewardAccumulator() *rewardAccumulator {
+	return &rewardAccumulator{m: map[rewardKey]*rewardStat{}}
+}
+
+func (r *rewardAccumulator) add(class TrafficClass, exitId string, goodputBytes float64, stallFree bool) {
+	k := rewardKey{Class: class, ExitId: exitId}
+	s := r.m[k]
+	if s == nil {
+		s = &rewardStat{}
+		r.m[k] = s
+	}
+	s.samples++
+	s.goodputSum += goodputBytes
+	if stallFree {
+		s.stallFreeN++
+	}
+}
+
+// drainLines emits one grammar line per key and resets. Interval-triggered by
+// the caller (the heartbeat tick), never per-packet.
+func (r *rewardAccumulator) drainLines() []string {
+	if len(r.m) == 0 {
+		return nil
+	}
+	lines := make([]string, 0, len(r.m))
+	for k, s := range r.m {
+		avg := s.goodputSum / float64(s.samples)
+		frac := float64(s.stallFreeN) / float64(s.samples)
+		lines = append(lines, fmt.Sprintf(
+			"%sevent=reward class=%s exit=%s samples=%d goodput=%.0f stallfree=%.2g",
+			relPrefix, k.Class, k.ExitId, s.samples, avg, frac))
+	}
+	r.m = map[rewardKey]*rewardStat{}
+	return lines
+}

--- a/routing_reward_test.go
+++ b/routing_reward_test.go
@@ -1,0 +1,57 @@
+package connect
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewardAccumulatorDrainLines(t *testing.T) {
+	r := newRewardAccumulator()
+	r.add(ClassBulk, "exitA", 1000, true)
+	r.add(ClassBulk, "exitA", 3000, false)
+	lines := r.drainLines()
+	if len(lines) != 1 {
+		t.Fatalf("want 1 line, got %d: %v", len(lines), lines)
+	}
+	l := lines[0]
+	for _, want := range []string{"[rel] event=reward", "class=bulk", "exit=exitA", "samples=2", "stallfree=0.5"} {
+		if !strings.Contains(l, want) {
+			t.Fatalf("line %q missing %q", l, want)
+		}
+	}
+	if len(r.drainLines()) != 0 {
+		t.Fatal("drain must reset the accumulator")
+	}
+}
+
+func TestRewardAccumulatorPerClassDivergence(t *testing.T) {
+	r := newRewardAccumulator()
+	r.add(ClassBulk, "exitA", 1000, true)
+	r.add(ClassLatency, "exitA", 2000, false)
+	lines := r.drainLines()
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines (one per class), got %d: %v", len(lines), lines)
+	}
+	// Verify that we got separate lines for each class
+	hasBulk := false
+	hasLatency := false
+	for _, line := range lines {
+		if strings.Contains(line, "class=bulk") {
+			hasBulk = true
+		}
+		if strings.Contains(line, "class=latency") {
+			hasLatency = true
+		}
+	}
+	if !hasBulk || !hasLatency {
+		t.Fatalf("lines must contain separate entries for bulk and latency: %v", lines)
+	}
+}
+
+func TestRewardAccumulatorEmptyDrain(t *testing.T) {
+	r := newRewardAccumulator()
+	lines := r.drainLines()
+	if lines != nil && len(lines) != 0 {
+		t.Fatalf("empty accumulator must return empty slice, not %v", lines)
+	}
+}

--- a/routing_score.go
+++ b/routing_score.go
@@ -40,28 +40,39 @@ func classWeights(c TrafficClass) ScoreWeights {
 }
 
 // exitScore returns a composite health score for an exit with the given metrics
-// and traffic class weights. The score is bounded and sanitized: inputs are
-// clamped to prevent NaN/Inf output, negative values are safe (mapped to 0),
-// and non-finite inputs are replaced with a safe finite default. Higher scores
-// indicate better exits. The function is pure: no locks, I/O, or time calls.
+// and traffic class weights. The score is bounded and sanitized to ensure
+// hostile telemetry (negative, NaN, +Inf values) scores as WORST, not best.
+// Higher scores indicate better exits. The function is pure: no locks, I/O,
+// or time calls.
+//
+// Telemetry from untrusted third-party providers can report garbage values.
+// A scoring function that fails toward "route traffic here" is worse than one
+// that fails toward "avoid this." Thus: positive infinity RTT (unreachable),
+// NaN RTT (unknown), or negative RTT (corrupt) all deserve the worst possible
+// sub-score (0.0), not the best (1.0 from clamping to 0ms).
 func exitScore(m ExitMetrics, w ScoreWeights) float64 {
-	// Sanitize inputs to ensure output is always finite.
-	rtt := m.RttMillis
-	if rtt < 0 || math.IsNaN(rtt) || math.IsInf(rtt, 0) {
-		rtt = 0
+	// Calculate sub-scores; guard RTT and Jitter against hostile inputs.
+	var rttGood float64
+	if m.RttMillis < 0 || math.IsNaN(m.RttMillis) || math.IsInf(m.RttMillis, 0) {
+		rttGood = 0 // worst score for corrupt/missing data
+	} else {
+		rttGood = 1.0 / (1.0 + m.RttMillis/50.0) // 50ms → 0.5
 	}
-	jitter := m.Jitter
-	if jitter < 0 || math.IsNaN(jitter) || math.IsInf(jitter, 0) {
-		jitter = 0
+
+	var jitterGood float64
+	if m.Jitter < 0 || math.IsNaN(m.Jitter) || math.IsInf(m.Jitter, 0) {
+		jitterGood = 0 // worst score for corrupt/missing data
+	} else {
+		jitterGood = 1.0 / (1.0 + m.Jitter/20.0) // 20ms → 0.5
 	}
+
+	// Goodput's clamp-to-0 behavior is correct (yields worst score), so no guard needed.
 	goodput := m.GoodputBytesPerSec
 	if goodput < 0 || math.IsNaN(goodput) || math.IsInf(goodput, 0) {
 		goodput = 0
 	}
-
-	rttGood := 1.0 / (1.0 + rtt/50.0)        // 50ms → 0.5
-	jitterGood := 1.0 / (1.0 + jitter/20.0)  // 20ms → 0.5
 	goodputGood := goodput / (goodput + 1e6) // 1MB/s → 0.5
+
 	stallPenalty := float64(m.StallEvents) * 0.1
 	return w.Rtt*rttGood + w.Goodput*goodputGood + w.Jitter*jitterGood - w.Stall*stallPenalty
 }

--- a/routing_score.go
+++ b/routing_score.go
@@ -99,3 +99,36 @@ func exitScore(m ExitMetrics, w ScoreWeights) float64 {
 func challengerWins(incumbent, challenger, hysteresisPct float64) bool {
 	return challenger > incumbent+math.Abs(incumbent)*hysteresisPct/100.0
 }
+
+// demotionState implements N-of-M rank demotion: an exit is only demoted after
+// needBad consecutive bad intervals, so a single noisy sample never re-ranks the
+// window. A good sample resets the streak. needBad<=1 is the legacy behavior
+// (act on every sample). Convictions are unaffected — they are evidence-based
+// and handled by the verdict layer, not by this score demotion.
+type demotionState struct {
+	bad int
+}
+
+func (d *demotionState) observe(good bool, needBad int) bool {
+	if good {
+		d.bad = 0
+		return false
+	}
+	d.bad++
+	return d.bad >= max(1, needBad)
+}
+
+// lessLoadedTieBreak returns true when challenger b should be preferred over
+// incumbent a. When neither strictly wins under hysteresis (a near-tie), the
+// less-loaded of the two wins — the power-of-two-choices anti-herding rule that
+// spreads flows instead of piling them on one favorite. Outside the margin the
+// higher score wins outright.
+func lessLoadedTieBreak(aScore, bScore float64, aFlows, bFlows int, hysteresisPct float64) bool {
+	if challengerWins(aScore, bScore, hysteresisPct) {
+		return true
+	}
+	if challengerWins(bScore, aScore, hysteresisPct) {
+		return false
+	}
+	return bFlows < aFlows
+}

--- a/routing_score.go
+++ b/routing_score.go
@@ -1,0 +1,57 @@
+package connect
+
+// ExitMetrics is the per-(class,exit) signal snapshot the scorer reads. Every
+// field is already collected elsewhere in this file's machinery; the scorer is
+// pure and holds no locks.
+type ExitMetrics struct {
+	RttMillis          float64
+	GoodputBytesPerSec float64
+	StallEvents        int
+	Jitter             float64
+	Flows              int
+}
+
+// ScoreWeights weights each normalized metric. Per-class weights let the same
+// scorer prefer low latency for interactive flows and high throughput for bulk.
+type ScoreWeights struct {
+	Rtt     float64
+	Goodput float64
+	Stall   float64
+	Jitter  float64
+}
+
+func classWeights(c TrafficClass) ScoreWeights {
+	switch c {
+	case ClassLatency:
+		return ScoreWeights{Rtt: 1.0, Goodput: 0.2, Stall: 1.0, Jitter: 0.8}
+	case ClassStreaming:
+		return ScoreWeights{Rtt: 0.4, Goodput: 0.8, Stall: 1.0, Jitter: 0.9}
+	case ClassBulk:
+		return ScoreWeights{Rtt: 0.1, Goodput: 1.0, Stall: 0.6, Jitter: 0.1}
+	case ClassBrowsing:
+		return ScoreWeights{Rtt: 0.6, Goodput: 0.6, Stall: 0.8, Jitter: 0.4}
+	case ClassBackground:
+		return ScoreWeights{Rtt: 0.2, Goodput: 0.7, Stall: 0.5, Jitter: 0.2}
+	default: // ClassUnknown: balanced, class-neutral
+		return ScoreWeights{Rtt: 0.5, Goodput: 0.5, Stall: 0.7, Jitter: 0.3}
+	}
+}
+
+// exitScore is a bounded composite in [0,1]-ish space; higher is better. RTT and
+// jitter are inverted (lower is better) via a soft reciprocal so a 0 metric does
+// not divide; stall events subtract. Constants are deliberate and unit-tested,
+// not tuned here.
+func exitScore(m ExitMetrics, w ScoreWeights) float64 {
+	rttGood := 1.0 / (1.0 + m.RttMillis/50.0)                          // 50ms → 0.5
+	jitterGood := 1.0 / (1.0 + m.Jitter/20.0)                          // 20ms → 0.5
+	goodputGood := m.GoodputBytesPerSec / (m.GoodputBytesPerSec + 1e6) // 1MB/s → 0.5
+	stallPenalty := float64(m.StallEvents) * 0.1
+	return w.Rtt*rttGood + w.Goodput*goodputGood + w.Jitter*jitterGood - w.Stall*stallPenalty
+}
+
+// challengerWins applies incumbent hysteresis: a challenger only displaces the
+// incumbent if it beats it by more than hysteresisPct percent. hysteresisPct==0
+// reduces to a plain greater-than, which is the pre-change behavior.
+func challengerWins(incumbent, challenger, hysteresisPct float64) bool {
+	return challenger > incumbent*(1.0+hysteresisPct/100.0)
+}

--- a/routing_score.go
+++ b/routing_score.go
@@ -73,7 +73,20 @@ func exitScore(m ExitMetrics, w ScoreWeights) float64 {
 	}
 	goodputGood := goodput / (goodput + 1e6) // 1MB/s → 0.5
 
-	stallPenalty := float64(m.StallEvents) * 0.1
+	// Clamp StallEvents: negative values (corrupt/underflowed counter) must never
+	// become a reward. Cap the penalty to prevent unboundedly negative scores:
+	// max positive contribution is ~3.0 (perfect RTT + Goodput + Jitter), so
+	// capping stallPenalty at 3.0 prevents hostile telemetry from pushing score
+	// below -3.0. This caps StallEvents at 30; normal ranges (<10) remain
+	// monotonically ordered.
+	stallCount := m.StallEvents
+	if stallCount < 0 {
+		stallCount = 0
+	}
+	stallPenalty := float64(stallCount) * 0.1
+	if stallPenalty > 3.0 {
+		stallPenalty = 3.0
+	}
 	return w.Rtt*rttGood + w.Goodput*goodputGood + w.Jitter*jitterGood - w.Stall*stallPenalty
 }
 

--- a/routing_score.go
+++ b/routing_score.go
@@ -1,5 +1,7 @@
 package connect
 
+import "math"
+
 // ExitMetrics is the per-(class,exit) signal snapshot the scorer reads. Every
 // field is already collected elsewhere in this file's machinery; the scorer is
 // pure and holds no locks.
@@ -37,21 +39,39 @@ func classWeights(c TrafficClass) ScoreWeights {
 	}
 }
 
-// exitScore is a bounded composite in [0,1]-ish space; higher is better. RTT and
-// jitter are inverted (lower is better) via a soft reciprocal so a 0 metric does
-// not divide; stall events subtract. Constants are deliberate and unit-tested,
-// not tuned here.
+// exitScore returns a composite health score for an exit with the given metrics
+// and traffic class weights. The score is bounded and sanitized: inputs are
+// clamped to prevent NaN/Inf output, negative values are safe (mapped to 0),
+// and non-finite inputs are replaced with a safe finite default. Higher scores
+// indicate better exits. The function is pure: no locks, I/O, or time calls.
 func exitScore(m ExitMetrics, w ScoreWeights) float64 {
-	rttGood := 1.0 / (1.0 + m.RttMillis/50.0)                          // 50ms → 0.5
-	jitterGood := 1.0 / (1.0 + m.Jitter/20.0)                          // 20ms → 0.5
-	goodputGood := m.GoodputBytesPerSec / (m.GoodputBytesPerSec + 1e6) // 1MB/s → 0.5
+	// Sanitize inputs to ensure output is always finite.
+	rtt := m.RttMillis
+	if rtt < 0 || math.IsNaN(rtt) || math.IsInf(rtt, 0) {
+		rtt = 0
+	}
+	jitter := m.Jitter
+	if jitter < 0 || math.IsNaN(jitter) || math.IsInf(jitter, 0) {
+		jitter = 0
+	}
+	goodput := m.GoodputBytesPerSec
+	if goodput < 0 || math.IsNaN(goodput) || math.IsInf(goodput, 0) {
+		goodput = 0
+	}
+
+	rttGood := 1.0 / (1.0 + rtt/50.0)        // 50ms → 0.5
+	jitterGood := 1.0 / (1.0 + jitter/20.0)  // 20ms → 0.5
+	goodputGood := goodput / (goodput + 1e6) // 1MB/s → 0.5
 	stallPenalty := float64(m.StallEvents) * 0.1
 	return w.Rtt*rttGood + w.Goodput*goodputGood + w.Jitter*jitterGood - w.Stall*stallPenalty
 }
 
-// challengerWins applies incumbent hysteresis: a challenger only displaces the
-// incumbent if it beats it by more than hysteresisPct percent. hysteresisPct==0
-// reduces to a plain greater-than, which is the pre-change behavior.
+// challengerWins applies incumbent hysteresis using an absolute-value margin:
+// a challenger only displaces the incumbent if it beats it by more than
+// hysteresisPct percent of the absolute incumbent value. This ensures the
+// threshold moves toward "better" regardless of score sign (positive, negative,
+// or zero incumbent). When hysteresisPct==0, reduces to plain greater-than for
+// all score signs, which is the legacy behavior and required by existing callers.
 func challengerWins(incumbent, challenger, hysteresisPct float64) bool {
-	return challenger > incumbent*(1.0+hysteresisPct/100.0)
+	return challenger > incumbent+math.Abs(incumbent)*hysteresisPct/100.0
 }

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -210,16 +210,19 @@ func TestLessLoadedTieBreak(t *testing.T) {
 }
 
 func TestLessLoadedTieBreakNegativeScores(t *testing.T) {
-	// Both exits are degraded (negative scores), but still in a near-tie:
-	// a=-10, b=-8 within 10% margin of -10 -> prefer less-loaded (b has 5 flows)
-	if !lessLoadedTieBreak(-10, -8, 30, 5, 10) {
+	// Both exits are degraded (negative scores), in a near-tie within 10% margin:
+	// a=-5, b=-4.9. Threshold for b: -5 + 0.5 = -4.5; -4.9 > -4.5 is false.
+	// Reverse: -4.9 + 0.49 = -4.41; -5 > -4.41 is false.
+	// Neither wins outright → flow comparison decides.
+	// With b less loaded (5 flows), prefer b.
+	if !lessLoadedTieBreak(-5, -4.9, 30, 5, 10) {
 		t.Fatal("near-tie with negative scores should prefer the less-loaded exit b")
 	}
-	// b clearly wins even with negative scores: a=-10, b=-2 is a clear gap
-	if !lessLoadedTieBreak(-10, -2, 30, 5, 10) {
-		t.Fatal("clear improvement in negative scores should have b win even with more load")
+	// Same scores, but now a is less loaded (5 flows): should NOT prefer b.
+	if lessLoadedTieBreak(-5, -4.9, 5, 30, 10) {
+		t.Fatal("near-tie with negative scores should prefer the less-loaded exit a, not b")
 	}
-	// a clearly wins even though both negative: a=-2, b=-10 is a clear gap
+	// a clearly wins even though both negative: a=-2, b=-10 is a clear gap.
 	if lessLoadedTieBreak(-2, -10, 30, 5, 10) {
 		t.Fatal("clear win for negative a should not be displaced by b's load")
 	}

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -71,16 +71,62 @@ func TestExitScoreBulkPrefersGoodput(t *testing.T) {
 
 func TestExitScoreSanitizesHostileInputs(t *testing.T) {
 	w := classWeights(ClassLatency)
-	// Hostile inputs that could produce NaN or Inf if not sanitized.
-	hostileMetrics := []ExitMetrics{
-		{RttMillis: -100, GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0},        // negative RTT
-		{RttMillis: 50, GoodputBytesPerSec: math.Inf(1), Jitter: 0, StallEvents: 0},  // +Inf goodput
-		{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: math.NaN(), StallEvents: 0}, // NaN jitter
-		{RttMillis: math.Inf(1), GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0}, // +Inf RTT
-		{RttMillis: math.NaN(), GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0},  // NaN RTT
+
+	// Baseline: a healthy exit with perfect latency and jitter.
+	healthy := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: 0}, w)
+
+	// Assertion 1: Hostile RTT must score WORSE than healthy (not better).
+	hostileRttCases := []struct {
+		name string
+		rtt  float64
+	}{
+		{"negative RTT", -100},
+		{"+Inf RTT", math.Inf(1)},
+		{"NaN RTT", math.NaN()},
+	}
+	for _, tc := range hostileRttCases {
+		hostile := exitScore(ExitMetrics{RttMillis: tc.rtt, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: 0}, w)
+		if !(hostile < healthy) {
+			t.Errorf("hostile %s: score=%f should be < healthy=%f", tc.name, hostile, healthy)
+		}
+		// Assertion 2: Hostile RTT must not win at 10% hysteresis.
+		if challengerWins(healthy, hostile, 10) {
+			t.Errorf("hostile %s should not win challengerWins against healthy at 10%%, score=%f vs incumbent=%f",
+				tc.name, hostile, healthy)
+		}
 	}
 
-	for i, m := range hostileMetrics {
+	// Assertion 3: Hostile Jitter must score WORSE than healthy.
+	hostileJitterCases := []struct {
+		name   string
+		jitter float64
+	}{
+		{"negative Jitter", -50},
+		{"+Inf Jitter", math.Inf(1)},
+		{"NaN Jitter", math.NaN()},
+	}
+	for _, tc := range hostileJitterCases {
+		hostile := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: tc.jitter, StallEvents: 0}, w)
+		if !(hostile < healthy) {
+			t.Errorf("hostile %s: score=%f should be < healthy=%f", tc.name, hostile, healthy)
+		}
+		// Assertion 4: Hostile Jitter must not win at 10% hysteresis.
+		if challengerWins(healthy, hostile, 10) {
+			t.Errorf("hostile %s should not win challengerWins against healthy at 10%%, score=%f vs incumbent=%f",
+				tc.name, hostile, healthy)
+		}
+	}
+
+	// Assertion 5: Finiteness check (no NaN/Inf output).
+	allHostileMetrics := []ExitMetrics{
+		{RttMillis: -100, GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0},
+		{RttMillis: 50, GoodputBytesPerSec: math.Inf(1), Jitter: 0, StallEvents: 0},
+		{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: math.NaN(), StallEvents: 0},
+		{RttMillis: math.Inf(1), GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0},
+		{RttMillis: math.NaN(), GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0},
+	}
+
+	for i, m := range allHostileMetrics {
 		score := exitScore(m, w)
 		if math.IsNaN(score) || math.IsInf(score, 0) {
 			t.Errorf("exitScore case %d returned non-finite: %f", i, score)

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -133,3 +133,51 @@ func TestExitScoreSanitizesHostileInputs(t *testing.T) {
 		}
 	}
 }
+
+func TestExitScoreGuardsStallEvents(t *testing.T) {
+	w := classWeights(ClassLatency)
+
+	// Baseline: healthy exit with 0 stalls.
+	healthy := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: 0}, w)
+
+	// Assertion 1: Negative StallEvents must not score higher than 0.
+	// Corrupt counter claiming -50 stalls must not become a reward.
+	negativeStalls := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: -50}, w)
+	if negativeStalls > healthy {
+		t.Errorf("negative stalls: score=%f should not be > healthy=%f", negativeStalls, healthy)
+	}
+
+	// Assertion 2: Negative StallEvents must not win at 10% hysteresis.
+	if challengerWins(healthy, negativeStalls, 10) {
+		t.Errorf("negative stalls should not win challengerWins against healthy at 10%%, score=%f vs incumbent=%f",
+			negativeStalls, healthy)
+	}
+
+	// Assertion 3: Ordering preserved across normal stall counts (0 < 1 < 5).
+	stall1 := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: 1}, w)
+	stall5 := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: 5}, w)
+
+	if !(healthy > stall1) {
+		t.Errorf("ordering: 0 stalls=%f should be > 1 stall=%f", healthy, stall1)
+	}
+	if !(stall1 > stall5) {
+		t.Errorf("ordering: 1 stall=%f should be > 5 stalls=%f", stall1, stall5)
+	}
+
+	// Assertion 4: Extreme stall count produces bounded, finite score.
+	// Cap is at 3.0 penalty, so stalls above 30 should all give the same score.
+	stall30 := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: 30}, w)
+	stall100 := exitScore(ExitMetrics{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: 20, StallEvents: 100}, w)
+
+	if math.IsNaN(stall30) || math.IsInf(stall30, 0) {
+		t.Errorf("stall30 returned non-finite: %f", stall30)
+	}
+	if math.IsNaN(stall100) || math.IsInf(stall100, 0) {
+		t.Errorf("stall100 returned non-finite: %f", stall100)
+	}
+	// Both should be identical (capped).
+	if stall30 != stall100 {
+		t.Errorf("both stall30=%f and stall100=%f should be capped identically, not %f",
+			stall30, stall100, stall100-stall30)
+	}
+}

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -1,0 +1,35 @@
+package connect
+
+import "testing"
+
+func TestChallengerWinsHysteresis(t *testing.T) {
+	// 10% margin: 105 does not beat 100, 111 does.
+	if challengerWins(100, 105, 10) {
+		t.Fatal("105 should not beat 100 at 10% hysteresis")
+	}
+	if !challengerWins(100, 111, 10) {
+		t.Fatal("111 should beat 100 at 10% hysteresis")
+	}
+	// zero hysteresis is plain greater-than (legacy behavior)
+	if !challengerWins(100, 100.5, 0) {
+		t.Fatal("zero hysteresis must be plain >")
+	}
+}
+
+func TestExitScoreLatencyPrefersLowRtt(t *testing.T) {
+	w := classWeights(ClassLatency)
+	fast := exitScore(ExitMetrics{RttMillis: 20, GoodputBytesPerSec: 1e6}, w)
+	slow := exitScore(ExitMetrics{RttMillis: 200, GoodputBytesPerSec: 1e6}, w)
+	if !(fast > slow) {
+		t.Fatalf("latency class must rank low-RTT higher: fast=%f slow=%f", fast, slow)
+	}
+}
+
+func TestExitScoreBulkPrefersGoodput(t *testing.T) {
+	w := classWeights(ClassBulk)
+	fat := exitScore(ExitMetrics{RttMillis: 80, GoodputBytesPerSec: 5e6}, w)
+	thin := exitScore(ExitMetrics{RttMillis: 80, GoodputBytesPerSec: 5e5}, w)
+	if !(fat > thin) {
+		t.Fatalf("bulk class must rank high-goodput higher: fat=%f thin=%f", fat, thin)
+	}
+}

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -252,17 +252,48 @@ func TestDefaultMultiClientSettingsKnobsAreZeroValueOff(t *testing.T) {
 // TestNewReliabilityKnobsZeroValueOff asserts the four smart-routing knobs
 // follow the same zero-value-off contract as every other ReliabilitySettings
 // field: a nil override (or one built from an older struct) must leave them
-// all off, and ReliabilitySettingsFrom must faithfully copy the knob through
-// when it is set.
+// all off, and ReliabilitySettingsFrom must faithfully copy every knob
+// through when it is set.
+//
+// The copy-fidelity half deliberately does NOT source its input from
+// DefaultMultiClientSettings(): the zero-value-off requirement means the
+// defaults leave all four knobs at false/0, so a comparison built on the
+// defaults (got.X != s.X) is false != false regardless of whether
+// ReliabilitySettingsFrom copies the field at all -- deleting the copy line
+// entirely would still pass. Instead an explicit, fully-populated
+// MultiClientSettings is round-tripped, with distinct non-zero values per
+// field (not the same 1 four times) so a copy line wired to the wrong
+// source field is caught too, not just a missing one.
 func TestNewReliabilityKnobsZeroValueOff(t *testing.T) {
 	z := ReliabilitySettingsFrom(nil) // nil → zero value
 	if z.ScoredPlacement || z.PlacementHysteresisPct != 0 ||
 		z.PlacementDemoteConsecutive != 0 || z.RewardInstrumentation {
 		t.Fatal("new knobs must be zero-value-off (legacy behavior)")
 	}
-	s := DefaultMultiClientSettings()
-	got := ReliabilitySettingsFrom(s)
-	if got.ScoredPlacement != s.ScoredPlacement {
+
+	d := DefaultMultiClientSettings()
+	if d.ScoredPlacement || d.PlacementHysteresisPct != 0 ||
+		d.PlacementDemoteConsecutive != 0 || d.RewardInstrumentation {
+		t.Fatal("DefaultMultiClientSettings must leave the new knobs zero-value-off")
+	}
+
+	src := &MultiClientSettings{
+		ScoredPlacement:            true,
+		PlacementHysteresisPct:     12.5,
+		PlacementDemoteConsecutive: 3,
+		RewardInstrumentation:      true,
+	}
+	got := ReliabilitySettingsFrom(src)
+	if got.ScoredPlacement != true {
 		t.Fatal("ReliabilitySettingsFrom must copy ScoredPlacement")
+	}
+	if got.PlacementHysteresisPct != 12.5 {
+		t.Fatalf("ReliabilitySettingsFrom must copy PlacementHysteresisPct: got %v, want 12.5", got.PlacementHysteresisPct)
+	}
+	if got.PlacementDemoteConsecutive != 3 {
+		t.Fatalf("ReliabilitySettingsFrom must copy PlacementDemoteConsecutive: got %v, want 3", got.PlacementDemoteConsecutive)
+	}
+	if got.RewardInstrumentation != true {
+		t.Fatal("ReliabilitySettingsFrom must copy RewardInstrumentation")
 	}
 }

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -1,18 +1,53 @@
 package connect
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestChallengerWinsHysteresis(t *testing.T) {
-	// 10% margin: 105 does not beat 100, 111 does.
-	if challengerWins(100, 105, 10) {
-		t.Fatal("105 should not beat 100 at 10% hysteresis")
+	tests := []struct {
+		name          string
+		incumbent     float64
+		challenger    float64
+		hysteresisPct float64
+		wantWins      bool
+	}{
+		// Positive incumbent cases (original brief tests)
+		{"positive: 105 does not beat 100 at 10%", 100, 105, 10, false},
+		{"positive: 111 beats 100 at 10%", 100, 111, 10, true},
+		{"positive: zero hysteresis is plain >", 100, 100.5, 0, true},
+
+		// Zero incumbent: hysteresis margin disappears, plain > applies.
+		{"zero incumbent: challenger > incumbent", 0, 0.1, 10, true},
+		{"zero incumbent: challenger <= incumbent", 0, 0, 10, false},
+		{"zero incumbent with 0% hysteresis", 0, 0.1, 0, true},
+
+		// Negative incumbent: the critical bug case.
+		// With old formula: incumbent=-5, pct=10 -> threshold=-5.5, so -5.2 "wins" (WRONG).
+		// With new formula: incumbent=-5, pct=10 -> threshold=-4.5, so -5.2 rejects, -4 accepts (CORRECT).
+		{"negative: -4 beats -5 at 10%", -5, -4, 10, true},
+		{"negative: -5.2 does not beat -5 at 10%", -5, -5.2, 10, false},
+		{"negative: zero hysteresis is plain >", -5, -4.9, 0, true},
+		{"negative: equal does not win", -5, -5, 10, false},
+
+		// Boundary: large negative incumbent with large hysteresis.
+		{"large negative: -100 needs 10% to reach -90", -100, -91, 10, false},
+		{"large negative: -100 at 10% margin beats -89", -100, -89, 10, true},
+
+		// Extremely close values near zero.
+		{"tiny positive challenger beats by margin", 0.001, 0.00111, 10, true},
+		{"tiny negative incumbent", -0.001, 0, 10, true},
 	}
-	if !challengerWins(100, 111, 10) {
-		t.Fatal("111 should beat 100 at 10% hysteresis")
-	}
-	// zero hysteresis is plain greater-than (legacy behavior)
-	if !challengerWins(100, 100.5, 0) {
-		t.Fatal("zero hysteresis must be plain >")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := challengerWins(tc.incumbent, tc.challenger, tc.hysteresisPct)
+			if got != tc.wantWins {
+				t.Errorf("challengerWins(%f, %f, %f) = %v, want %v",
+					tc.incumbent, tc.challenger, tc.hysteresisPct, got, tc.wantWins)
+			}
+		})
 	}
 }
 
@@ -31,5 +66,24 @@ func TestExitScoreBulkPrefersGoodput(t *testing.T) {
 	thin := exitScore(ExitMetrics{RttMillis: 80, GoodputBytesPerSec: 5e5}, w)
 	if !(fat > thin) {
 		t.Fatalf("bulk class must rank high-goodput higher: fat=%f thin=%f", fat, thin)
+	}
+}
+
+func TestExitScoreSanitizesHostileInputs(t *testing.T) {
+	w := classWeights(ClassLatency)
+	// Hostile inputs that could produce NaN or Inf if not sanitized.
+	hostileMetrics := []ExitMetrics{
+		{RttMillis: -100, GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0},        // negative RTT
+		{RttMillis: 50, GoodputBytesPerSec: math.Inf(1), Jitter: 0, StallEvents: 0},  // +Inf goodput
+		{RttMillis: 50, GoodputBytesPerSec: 1e6, Jitter: math.NaN(), StallEvents: 0}, // NaN jitter
+		{RttMillis: math.Inf(1), GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0}, // +Inf RTT
+		{RttMillis: math.NaN(), GoodputBytesPerSec: 1e6, Jitter: 0, StallEvents: 0},  // NaN RTT
+	}
+
+	for i, m := range hostileMetrics {
+		score := exitScore(m, w)
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			t.Errorf("exitScore case %d returned non-finite: %f", i, score)
+		}
 	}
 }

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -181,3 +181,46 @@ func TestExitScoreGuardsStallEvents(t *testing.T) {
 			stall30, stall100, stall100-stall30)
 	}
 }
+
+func TestDemotionNeedsNofM(t *testing.T) {
+	d := &demotionState{}
+	if d.observe(false, 3) || d.observe(false, 3) {
+		t.Fatal("demoted before 3 consecutive bad")
+	}
+	if !d.observe(false, 3) {
+		t.Fatal("should demote on 3rd consecutive bad")
+	}
+	d2 := &demotionState{}
+	d2.observe(false, 3)
+	d2.observe(true, 3) // recovery resets
+	if d2.observe(false, 3) {
+		t.Fatal("a good sample must reset the streak")
+	}
+}
+
+func TestLessLoadedTieBreak(t *testing.T) {
+	// within 10% margin → prefer less-loaded (b has fewer flows)
+	if !lessLoadedTieBreak(100, 105, 30, 5, 10) {
+		t.Fatal("near-tie should prefer the less-loaded exit b")
+	}
+	// b clearly worse → keep a even though a is more loaded
+	if lessLoadedTieBreak(100, 60, 30, 5, 10) {
+		t.Fatal("clear score gap must beat load tie-break")
+	}
+}
+
+func TestLessLoadedTieBreakNegativeScores(t *testing.T) {
+	// Both exits are degraded (negative scores), but still in a near-tie:
+	// a=-10, b=-8 within 10% margin of -10 -> prefer less-loaded (b has 5 flows)
+	if !lessLoadedTieBreak(-10, -8, 30, 5, 10) {
+		t.Fatal("near-tie with negative scores should prefer the less-loaded exit b")
+	}
+	// b clearly wins even with negative scores: a=-10, b=-2 is a clear gap
+	if !lessLoadedTieBreak(-10, -2, 30, 5, 10) {
+		t.Fatal("clear improvement in negative scores should have b win even with more load")
+	}
+	// a clearly wins even though both negative: a=-2, b=-10 is a clear gap
+	if lessLoadedTieBreak(-2, -10, 30, 5, 10) {
+		t.Fatal("clear win for negative a should not be displaced by b's load")
+	}
+}

--- a/routing_score_test.go
+++ b/routing_score_test.go
@@ -227,3 +227,42 @@ func TestLessLoadedTieBreakNegativeScores(t *testing.T) {
 		t.Fatal("clear win for negative a should not be displaced by b's load")
 	}
 }
+
+// TestDefaultMultiClientSettingsKnobsAreZeroValueOff pins the actual
+// regression risk: a default build must behave exactly like today. If a
+// future well-meaning edit ever sets one of these in
+// DefaultMultiClientSettings, this test catches it before it ships and
+// silently opts every default build into the new placement/reward behavior.
+func TestDefaultMultiClientSettingsKnobsAreZeroValueOff(t *testing.T) {
+	s := DefaultMultiClientSettings()
+	if s.ScoredPlacement {
+		t.Fatal("DefaultMultiClientSettings must leave ScoredPlacement off (false)")
+	}
+	if s.PlacementHysteresisPct != 0 {
+		t.Fatal("DefaultMultiClientSettings must leave PlacementHysteresisPct at 0")
+	}
+	if s.PlacementDemoteConsecutive != 0 {
+		t.Fatal("DefaultMultiClientSettings must leave PlacementDemoteConsecutive at 0")
+	}
+	if s.RewardInstrumentation {
+		t.Fatal("DefaultMultiClientSettings must leave RewardInstrumentation off (false)")
+	}
+}
+
+// TestNewReliabilityKnobsZeroValueOff asserts the four smart-routing knobs
+// follow the same zero-value-off contract as every other ReliabilitySettings
+// field: a nil override (or one built from an older struct) must leave them
+// all off, and ReliabilitySettingsFrom must faithfully copy the knob through
+// when it is set.
+func TestNewReliabilityKnobsZeroValueOff(t *testing.T) {
+	z := ReliabilitySettingsFrom(nil) // nil → zero value
+	if z.ScoredPlacement || z.PlacementHysteresisPct != 0 ||
+		z.PlacementDemoteConsecutive != 0 || z.RewardInstrumentation {
+		t.Fatal("new knobs must be zero-value-off (legacy behavior)")
+	}
+	s := DefaultMultiClientSettings()
+	got := ReliabilitySettingsFrom(s)
+	if got.ScoredPlacement != s.ScoredPlacement {
+		t.Fatal("ReliabilitySettingsFrom must copy ScoredPlacement")
+	}
+}


### PR DESCRIPTION
Foundation for learned, class-aware exit selection. **Every knob is zero-value-off, so merging this changes no behavior on any platform.** It adds the scoring machinery and its tests; the inputs that would make it act land separately.

## Why

Today's placement picks exits by tier and flow count. It has no notion of what a flow *is*, so a video call and a torrent get the same treatment, and a well-behaved exit that happens to be busy loses to a marginal idle one. This adds the vocabulary and the arithmetic for a better decision without yet making one.

## What is here

- `routing_class.go` — five traffic classes (latency, streaming, bulk, browsing, background) and a nil-safe `FlowClassifier` seam. `ClassUnknown` is the zero value and means "fall through to the legacy order".
- `routing_score.go` — deterministic per-class `exitScore`, incumbent hysteresis, N-of-M rank demotion, and a power-of-two-choices less-loaded tie-break for anti-herding.
- `routing_priors.go` — coarse per-provider-identity priors (EWMA + conviction bias). Presence-keyed: a conviction against an unseen provider creates a penalized entry rather than a neutral one.
- `routing_reward.go` — per-(class, exit) reward instrumentation.
- `ip_remote_multi_client.go` — the knobs, and `scoredPlacementReorder` behind its gate.

## The safety property

`scoredPlacementReorder` **only re-orders**. It never adds, removes, or unquarantines a candidate — `raceCandidates` has already applied every verdict, quarantine, tier and flow-cap gate before the scorer sees the list. The learner cannot override the safety layer; it only expresses a preference within an already-safe set. That is deliberate and worth holding us to in review.

## Honest state

This is a foundation, not a working feature. With `ScoredPlacement` on today, `classifyOrUnknown` returns `ClassUnknown` (no classifier implementation exists yet) and the candidate list is returned untouched. Real telemetry, a classifier, and the reward tap are the follow-up. We are shipping the arithmetic first, with tests, so it can be reviewed on its own terms rather than buried inside the change that switches it on.

## Hardening already applied

Several defects were found and fixed during review of this work, and their tests are included:
- hysteresis inverted its sign for negative incumbent scores
- input sanitization clamped hostile RTT/Jitter to 0, which is the *best* sub-score, not a neutral one — so the guard now applies to sub-scores rather than inputs
- unguarded negative `StallEvents` became a bonus; now clamped, with the penalty bounded
- convictions against an absent provider created a neutral entry instead of a penalized one

## Verification

```
go build ./...   clean against upstream/main
go vet ./...     clean (one pre-existing unsafe.Pointer finding, untouched)
42 routing tests pass
```

Cherry-picked onto `upstream/main` and verified to compile and test there standalone — it does not depend on our beta stack.