### PR TITLE
ci: build and test on push and pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test — connect
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: go test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out connect
+        uses: actions/checkout@v4
+
+      # go.mod resolves this with `replace github.com/urnetwork/glog => ../glog`,
+      # so it has to sit beside the checkout
+      - name: Check out glog dependency
+        run: git clone --depth 1 https://github.com/urnetwork/glog.git ../glog
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Build
+        run: go build ./...
+
+      # -count=1 defeats the test result cache so a green run always means the
+      # tests actually ran. the root package (the data path) takes ~9 min.
+      - name: Test
+        run: go test -count=1 -timeout 20m $(go list ./... | grep -v '/extender$')
+
+      # extender's TestExtender fails on a fresh checkout, before any change of
+      # ours: it sleeps a fixed 1s for its TLS and extender listeners to come up
+      # (extender_test.go:71) and then fails the request with EOF, which is what
+      # racing a not-yet-listening socket looks like on a loaded runner. It is a
+      # separate transport component, not the multi-client data path, so it is
+      # reported but not allowed to gate. Remove this step once the startup race
+      # is fixed.
+      - name: Test extender (known flaky, non-blocking)
+        continue-on-error: true
+        run: go test -count=1 -timeout 5m ./extender/...


### PR DESCRIPTION
There is no CI in this repo today, so nothing catches a build break or a test regression before it lands. This adds one job: build, then test.

Build and test only — no release, publish, or artifact steps.

## What it does

```
git clone --depth 1 https://github.com/urnetwork/glog.git ../glog
go build ./...
go test -count=1 -timeout 20m $(go list ./... | grep -v '/extender$')
```

The glog clone is load-bearing: `go.mod` resolves it with `replace github.com/urnetwork/glog => ../glog`, so a lone checkout cannot build. It fails with a `missing go.sum entry` that never names the real cause, which makes it a genuinely confusing first-contributor experience.

`-count=1` defeats the test result cache, so a green run always means the tests actually ran rather than replaying an earlier result.

## Two deliberate choices worth reviewing

**`extender` runs `continue-on-error`.** `TestExtender` sleeps a fixed 1s waiting for its TLS and extender listeners (`extender_test.go:71`), then fails the request with EOF when it races a not-yet-listening socket on a loaded runner. It fails on a clean checkout, before any change. It still runs and still reports — it just does not gate a merge, because a check that is red for reasons unrelated to the PR trains everyone to ignore red. The step comment says to remove this once the startup race is fixed.

**No `-race`, and a finite timeout** — deliberately unlike `test.sh`. That script runs `-race -timeout 0` because these are real-time packet paths where a fixed deadline produces false failures, and it works around the race detector's scheduling overhead by running the timing-sensitive groups first in their own process. An infinite timeout means a stall hangs forever instead of failing, which is the wrong trade for a PR signal. Happy to add a separate non-blocking race job if you would rather have that coverage.

## Verification

Run on a fork before opening this: **all steps green in 10m16s**, including the full `Test` step (the root package alone is ~9 minutes) and `extender`. Not a skipped or cached pass.

## One unrelated observation

This repo has no `.gitattributes`. On a Windows checkout with `core.autocrlf=true` (Git for Windows' default), `.go` files land with CRLF, and five tests that assert against source text then fail — the four `*SourceAnchors` tests and `TestBusyProbeInterposesOnlyOnTheSendStallPath`. `gofmt -l` also flags every file. Re-checking out with LF makes all five pass. A `* text=auto eol=lf` `.gitattributes` would fix it for every Windows contributor, but it changes checkout behavior repo-wide, so it seemed like your call rather than something to fold into a CI change. Happy to send it separately if useful.

(Separately, `TestCombineTrim`, `TestPump` and `TestPumpTrim` in `transport_pt_queue_test.go` assert wall-clock pump throughput and fail on some machines while passing on CI runners. Not addressed here.)